### PR TITLE
Add /post endpoint to notify updates

### DIFF
--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -74,5 +74,14 @@
             "baseUrl": "#(service.uri)",
             "path": "/api/v1/subscriptions/:id/unsubscribe"
         }]
+    }, {
+        "url": "/subscriptions/notify-updates/:dataset",
+        "method": "POST",
+        "authenticated": false,
+        "endpoints": [{
+            "method": "POST",
+            "baseUrl": "#(service.uri)",
+            "path": "/api/v1/subscriptions/notify-updates/:dataset"
+        }]
     }]
 }

--- a/app/src/services/updateService.js
+++ b/app/src/services/updateService.js
@@ -32,7 +32,7 @@ class UpdateService {
         let lastUpdated = yield LastUpdate.findOne({dataset: dataset}).exec();
         logger.debug('Last updated', lastUpdated);
 
-        if (lastUpdated.date === latest.maxDate){
+        if (!lastUpdated || lastUpdated.date === latest.maxDate){
             logger.info(`Dataset ${dataset} was not updated`);
             return {
                 updated: false

--- a/config/default.json
+++ b/config/default.json
@@ -8,11 +8,11 @@
     "service": {
         "id": "gfw-subscription-api_1.0.0",
         "name": "GFW SUBSCRIPTION API",
-        "uri": "http://192.168.99.100:3200",
+        "uri": "http://192.168.1.109:3200",
         "port": 3600
     },
     "apiGateway": {
-        "uri": "http://192.168.99.100:8000/gateway/service",
+        "uri": "http://192.168.1.109:8000/gateway/service",
         "queue": "redis://localhost:6379"
     },
     "redisLocal": {
@@ -21,7 +21,7 @@
     },
     "mongodb": {
         "database": "gfw_subscription_db",
-        "host": "192.168.99.100",
+        "host": "192.168.1.109",
         "port": 32780
     },
     "migrate": {

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -9,9 +9,9 @@ develop:
     NODE_ENV: dev
     CARTODB_USER: wri-01
     FLAGSHIP_URL: http://staging.globalforestwatch.org
-    API_GATEWAY_URL: http://192.168.99.100:8000
-    API_GATEWAY_EXTERNAL_URL: http://192.168.99.100:8000
-    API_GATEWAY_QUEUE_URL: redis://192.168.99.100:6379
+    API_GATEWAY_URL: http://192.168.1.109:8000
+    API_GATEWAY_EXTERNAL_URL: http://192.168.1.109:8000
+    API_GATEWAY_QUEUE_URL: redis://192.168.1.109:6379
     API_GATEWAY_QUEUE_PROVIDER: redis
     API_GATEWAY_QUEUE_NAME: mail
     MIGRATE_URI: <migrateuri>
@@ -34,7 +34,5 @@ mongo:
   ports:
     - "27017"
   volumes:
-    # in osx the host machine volume directory cannot be under /Users
-    # http://stackoverflow.hex1.ru/questions/34390220/how-to-mount-external-volume-for-mongodb-using-docker-compose-and-docker-machine
-    - /var/docker/data/gfw-subscription-api:/data/db
+    - $HOME/docker/data/gfw-subscription-api:/data/db
   restart: always


### PR DESCRIPTION
This feature adds a `/post` endpoint  to notify when a dataset was updated which path is `subscriptions/notify-updates/:dataset`

It will check the database with lastUpdate and trigger the emails sends but I couldn't test because the locally database is empty.