### PR TITLE
Add name-spacing by application to subscription statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 22/01/2020
 - Add support for webhook-based subscription notifications.
+- Add application field to statistics so that stats can be namespaced by application.
 
 # 28/11/2019
 - Use dataset's metadata name field on subscription emails, instead of dataset's name

--- a/app/src/models/statistic.js
+++ b/app/src/models/statistic.js
@@ -4,6 +4,9 @@ const { Schema } = mongoose;
 
 const Statistic = new Schema({
     slug: { type: String, required: true, trim: true },
+    application: {
+        type: String, required: true, trim: true, default: 'gfw'
+    },
     createdAt: { type: Date, required: true, default: Date.now }
 });
 

--- a/app/src/models/statistic.js
+++ b/app/src/models/statistic.js
@@ -4,7 +4,7 @@ const { Schema } = mongoose;
 
 const Statistic = new Schema({
     slug: { type: String, required: true, trim: true },
-    application: { type: String, required: true, trim: true },
+    application: { type: String, trim: true },
     createdAt: { type: Date, required: true, default: Date.now }
 });
 

--- a/app/src/models/statistic.js
+++ b/app/src/models/statistic.js
@@ -4,9 +4,7 @@ const { Schema } = mongoose;
 
 const Statistic = new Schema({
     slug: { type: String, required: true, trim: true },
-    application: {
-        type: String, required: true, trim: true, default: 'gfw'
-    },
+    application: { type: String, required: true, trim: true },
     createdAt: { type: Date, required: true, default: Date.now }
 });
 

--- a/app/src/models/subscription.js
+++ b/app/src/models/subscription.js
@@ -46,7 +46,7 @@ const Subscription = new Schema({
     },
     createdAt: { type: Date, required: true, default: Date.now },
     updateAt: { type: Date, required: false, default: Date.now },
-    application: { type: String, required: true, trim: true },
+    application: { type: String, trim: true },
     env: { type: String, required: true, default: 'production' }
 });
 
@@ -79,11 +79,7 @@ Subscription.methods.publish = async function (layerConfig, begin, end) {
 
     await alertPublishers[this.resource.type].publish(this, results, layer);
     logger.info('Saving statistic');
-    await new Statistic({
-        slug: layerConfig.slug,
-        application: this.application,
-    }).save();
-
+    await new Statistic({ slug: layerConfig.slug, application: this.application }).save();
     return true;
 };
 

--- a/app/src/models/subscription.js
+++ b/app/src/models/subscription.js
@@ -46,7 +46,9 @@ const Subscription = new Schema({
     },
     createdAt: { type: Date, required: true, default: Date.now },
     updateAt: { type: Date, required: false, default: Date.now },
-    application: { type: String, trim: true },
+    application: {
+        type: String, required: true, default: 'gfw', trim: true
+    },
     env: { type: String, required: true, default: 'production' }
 });
 

--- a/app/src/models/subscription.js
+++ b/app/src/models/subscription.js
@@ -46,9 +46,7 @@ const Subscription = new Schema({
     },
     createdAt: { type: Date, required: true, default: Date.now },
     updateAt: { type: Date, required: false, default: Date.now },
-    application: {
-        type: String, required: true, default: 'gfw', trim: true
-    },
+    application: { type: String, required: true, trim: true },
     env: { type: String, required: true, default: 'production' }
 });
 

--- a/app/src/models/subscription.js
+++ b/app/src/models/subscription.js
@@ -81,7 +81,10 @@ Subscription.methods.publish = async function (layerConfig, begin, end) {
 
     await alertPublishers[this.resource.type].publish(this, results, layer);
     logger.info('Saving statistic');
-    await new Statistic({ slug: layerConfig.slug }).save();
+    await new Statistic({
+        slug: layerConfig.slug,
+        application: this.application,
+    }).save();
 
     return true;
 };

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -208,7 +208,7 @@ class SubscriptionsRouter {
         logger.info('Obtaining statistics');
         ctx.assert(ctx.query.start, 400, 'Start date required');
         ctx.assert(ctx.query.end, 400, 'End date required');
-        ctx.body = await StatisticsService.getStatistics(new Date(ctx.query.start), new Date(ctx.query.end));
+        ctx.body = await StatisticsService.getStatistics(new Date(ctx.query.start), new Date(ctx.query.end), ctx.query.application);
     }
 
     static async statisticsGroup(ctx) {

--- a/app/src/services/statisticsService.js
+++ b/app/src/services/statisticsService.js
@@ -28,14 +28,12 @@ class StatisticsService {
 
     }
 
-    static async getTopSubscriptions(startDate, endDate) {
-        logger.debug(`Obtaining getTopSubscriptions with startDate ${startDate} and endDate ${endDate}`);
+    static async getTopSubscriptions(startDate, endDate, application) {
+        logger.debug(`Obtaining getTopSubscriptions with startDate ${startDate}, endDate ${endDate} and application ${application}`);
         const topSubs = {};
         const defaultFilter = {
-            createdAt: {
-                $gte: startDate,
-                $lt: endDate
-            }
+            createdAt: { $gte: startDate, $lt: endDate },
+            application: { $eq: application },
         };
         topSubs.geostore = await SubscriptionModel.count({
             ...defaultFilter,
@@ -93,13 +91,10 @@ class StatisticsService {
     }
 
     static async infoByUserSubscriptions(startDate, endDate, application) {
-        logger.debug(`Obtaining  subscriptions with startDate ${startDate} and endDate ${endDate} and application ${application}`);
+        logger.debug(`Obtaining  subscriptions with startDate ${startDate}, endDate ${endDate} and application ${application}`);
         const filter = {
-            createdAt: {
-                $gte: startDate,
-                $lt: endDate
-            },
-            application
+            createdAt: { $gte: startDate, $lt: endDate },
+            application: { $eq: application },
         };
 
         const subscriptions = await SubscriptionModel.find(filter);
@@ -118,16 +113,11 @@ class StatisticsService {
     }
 
     static async infoGroupSubscriptions(startDate, endDate, application) {
-        logger.debug(`Obtaining group subscriptions with startDate ${startDate} and endDate ${endDate} and application ${application}`);
+        logger.debug(`Obtaining group subscriptions with startDate ${startDate}, endDate ${endDate} and application ${application}`);
         const filter = {
-            createdAt: {
-                $gte: startDate,
-                $lt: endDate
-            },
-            datasets: {
-                $ne: []
-            },
-            application
+            createdAt: { $gte: startDate, $lt: endDate },
+            datasets: { $ne: [] },
+            application: { $eq: application },
         };
 
         const subscriptions = await SubscriptionModel.find(filter);
@@ -207,58 +197,53 @@ class StatisticsService {
         return data;
     }
 
-    static async infoSubscriptions(startDate, endDate) {
-        logger.debug(`Obtaining infoSubscriptions with startDate ${startDate} and endDate ${endDate}`);
+    static async infoSubscriptions(startDate, endDate, application) {
+        logger.debug(`Obtaining infoSubscriptions with startDate ${startDate}, endDate ${endDate} and application ${application}`);
         const info = {};
 
         const defaultFilter = {
-            createdAt: {
-                $gte: startDate,
-                $lt: endDate
-            }
+            createdAt: { $gte: startDate, $lt: endDate },
+            application: { $eq: application },
         };
 
         info.numSubscriptions = await SubscriptionModel.count(defaultFilter);
         info.totalSubscriptions = await SubscriptionModel.count();
-        logger.debug(SubscriptionModel.aggregate([{
-            $group: {
-                _id: '$userId'
-            }
-        }, {
-            $group: {
-                _id: 1,
-                count: {
-                    $sum: 1
+        logger.debug(SubscriptionModel.aggregate([
+            { $match: { application: { $eq: application } } },
+            { $group: { _id: '$userId' } },
+            {
+                $group: {
+                    _id: 1,
+                    count: {
+                        $sum: 1
+                    }
                 }
-            }
-        }]));
-        info.usersWithSubscriptions = await SubscriptionModel.aggregate([{
-            $group: {
-                _id: '$userId'
-            }
-        }, {
-            $group: {
-                _id: 1,
-                count: {
-                    $sum: 1
+            }]));
+        const usersWithSubscriptionResult = await SubscriptionModel.aggregate([
+            { $match: { application: { $eq: application } } },
+            { $group: { _id: '$userId' } },
+            {
+                $group: {
+                    _id: 1,
+                    count: { $sum: 1 }
                 }
-            }
-        }]).exec();
-        if (info.usersWithSubscriptions) {
-            info.usersWithSubscriptions = info.usersWithSubscriptions[0].count;
-        }
+            }]).exec();
+        info.usersWithSubscriptions = usersWithSubscriptionResult.length > 0
+            ? usersWithSubscriptionResult[0].count
+            : 0;
         info.totalEmailsSentInThisQ = await StatisticModel.count(defaultFilter);
         info.totalEmailsSended = await StatisticModel.count();
 
         return info;
     }
 
-    static async getNewUsersWithSubs(startDate, endDate, users) {
+    static async getNewUsersWithSubs(users, application) {
         let usersCount = 0;
         if (users) {
             for (let i = 0, { length } = users; i < length; i++) {
                 usersCount += await SubscriptionModel.count({
-                    userId: users[i].id
+                    userId: users[i].id,
+                    application: { $eq: application },
                 });
             }
         }
@@ -267,10 +252,10 @@ class StatisticsService {
 
     static async getStatistics(startDate, endDate, application = 'gfw') {
         const users = await StatisticsService.getUsers(startDate, endDate);
-        const topSubs = await StatisticsService.getTopSubscriptions(startDate, endDate);
-        const info = await StatisticsService.infoSubscriptions(startDate, endDate);
+        const topSubs = await StatisticsService.getTopSubscriptions(startDate, endDate, application);
+        const info = await StatisticsService.infoSubscriptions(startDate, endDate, application);
         const groupStatistics = await StatisticsService.infoGroupSubscriptions(startDate, endDate, application);
-        const usersWithSubscription = await StatisticsService.getNewUsersWithSubs(startDate, endDate, users);
+        const usersWithSubscription = await StatisticsService.getNewUsersWithSubs(users, application);
         return {
             topSubscriptions: topSubs,
             info,

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -22,7 +22,7 @@ class SubscriptionService {
             resource: subscription.resource,
             datasets: subscription.datasets,
             datasetsQuery: subscription.datasetsQuery,
-            application: subscription.application || 'gfw',
+            application: subscription.application || null,
             language: subscription.language,
             env: subscription.env || 'production'
         };

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -22,7 +22,7 @@ class SubscriptionService {
             resource: subscription.resource,
             datasets: subscription.datasets,
             datasetsQuery: subscription.datasetsQuery,
-            application: subscription.application || null,
+            application: subscription.application || 'gfw',
             language: subscription.language,
             env: subscription.env || 'production'
         };

--- a/app/test/e2e/statistic-group.spec.js
+++ b/app/test/e2e/statistic-group.spec.js
@@ -1,14 +1,12 @@
 /* eslint-disable no-unused-vars,no-undef */
 const nock = require('nock');
 const Subscription = require('models/subscription');
-const Statistic = require('models/statistic');
 const chai = require('chai');
 const { getTestServer } = require('./utils/test-server');
 const {
     createAuthCases, ensureCorrectError, getDateWithDecreaseYear, getDateWithIncreaseYear
 } = require('./utils/helpers');
 const { ROLES } = require('./utils/test.constants');
-const { createMockUsersWithRange } = require('./utils/mock');
 const { createSubscriptions, createExpectedGroupStatistics } = require('./utils/helpers/statistic');
 
 const should = chai.should();

--- a/app/test/e2e/statistic.spec.js
+++ b/app/test/e2e/statistic.spec.js
@@ -74,7 +74,7 @@ describe('Subscription statistic endpoint', () => {
         createMockUsersWithRange(startDate, endDate);
 
         const subscriptions = await createSubscriptions(outRangeDate);
-        const statistics = await createStatistics(outRangeDate);
+        const statistics = await createStatistics(outRangeDate, 'gfw');
 
         const totalSubscriptions = Object.keys(subscriptions).length;
         const totalSubscriptionsInSearchedRange = Object.keys(subscriptions).length - 1;
@@ -121,7 +121,7 @@ describe('Subscription statistic endpoint', () => {
         createMockUsersWithRange(startDate, endDate);
 
         const subscriptions = await createSubscriptions(outRangeDate);
-        const statistics = await createStatistics(outRangeDate);
+        const statistics = await createStatistics(outRangeDate, 'gfw');
 
         const totalSubscriptions = Object.keys(subscriptions).length;
         const totalSubscriptionsInSearchedRange = Object.keys(subscriptions).length - 1;

--- a/app/test/e2e/utils/helpers.js
+++ b/app/test/e2e/utils/helpers.js
@@ -37,8 +37,9 @@ const createSubscription = (userId, datasetUuid = null, data = {}) => {
 
 const createSubInDB = (userId, datasetUuid = null, data = {}) => new Subscription(createSubscription(userId, datasetUuid, data)).save();
 
-const createStatistic = (createdAt = new Date()) => new Statistic({
+const createStatistic = (createdAt = new Date(), application = 'gfw') => new Statistic({
     slug: 'viirs-active-fires',
+    application,
     createdAt,
 }).save();
 

--- a/app/test/e2e/utils/helpers/statistic.js
+++ b/app/test/e2e/utils/helpers/statistic.js
@@ -16,11 +16,11 @@ const createSubscriptions = async (outRangeDate) => {
 };
 
 // creating two statistics which are in searched range, and one which is not.
-const createStatistics = (outRangeDate) => {
+const createStatistics = (outRangeDate, application) => {
     const statisticData = [
-        createStatistic(),
-        createStatistic(),
-        createStatistic(outRangeDate)
+        createStatistic(undefined, application),
+        createStatistic(undefined, application),
+        createStatistic(outRangeDate, application)
     ];
     return Promise.all(statisticData.map((createStat) => createStat));
 };


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/n/projects/1883443/stories/170378136

## What does this PR add?
This PR adds name-spacing by application to subscription statistics, allowing then to extract stats reports by application - as stated it was needed [here](https://www.pivotaltracker.com/n/projects/1374154/stories/169905270).

It is also assumed that the default application is 'gfw', but this might need to be changed - this is being discussed [in this PT task](https://www.pivotaltracker.com/story/show/170311809).