### PR TITLE
Add endpoints find-by-ids and finding subscriptions for a user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 19/02/2020
-- Add endpoint for finding subscriptions by id - can only be called by other MSs.
-- Add endpoint for finding all subscriptions for a given user - can only be called by other MSs.
+- Add endpoint for finding subscriptions by id.
+- Add endpoint for finding all subscriptions for a given user.
 - Add possibility of creating, updating or deleting subscriptions that belong to other users when endpoints are called by other MSs.
 
 # 22/01/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 19/02/2020
+- Add endpoint for finding subscriptions by id - can only be called by other MSs.
+- Add endpoint for finding all subscriptions for a given user - can only be called by other MSs.
+- Add possibility of creating, updating or deleting subscriptions that belong to other users when endpoints are called by other MSs.
+
 # 22/01/2020
 - Add support for webhook-based subscription notifications.
 

--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -48,6 +48,24 @@
             "path": "/api/v1/subscriptions/:id"
         }]
     }, {
+        "url": "/v1/subscriptions/find-by-ids",
+        "method": "POST",
+        "authenticated": true,
+        "endpoints": [{
+            "method": "POST",
+            "baseUrl": "#(service.uri)",
+            "path": "/api/v1/subscriptions/find-by-ids"
+        }]
+    }, {
+        "url": "/v1/subscriptions/user/:userId",
+        "method": "GET",
+        "authenticated": true,
+        "endpoints": [{
+            "method": "GET",
+            "baseUrl": "#(service.uri)",
+            "path": "/api/v1/subscriptions/user/:userId"
+        }]
+    }, {
         "url": "/v1/subscriptions/:id",
         "method": "GET",
         "authenticated": true,

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -251,7 +251,7 @@ class SubscriptionsRouter {
 
     static async findByIds(ctx) {
         logger.info(`[SubscriptionsRouter] Getting all subscriptions with ids`, ctx.request.body);
-        if (ctx.request && ctx.request.body && ctx.request.body && ctx.request.body.ids.length > 0) {
+        if (ctx.request && ctx.request.body && ctx.request.body.ids && ctx.request.body.ids.length > 0) {
             const subscriptions = await SubscriptionService.getSubscriptionsByIds(ctx.request.body.ids);
             ctx.body = { data: subscriptions };
         } else {

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -249,6 +249,25 @@ class SubscriptionsRouter {
         ctx.body = await StatisticsService.infoByUserSubscriptions(new Date(ctx.query.start), new Date(ctx.query.end), ctx.query.application);
     }
 
+    static async findByIds(ctx) {
+        logger.info(`[SubscriptionsRouter] Getting all subscriptions with ids`, ctx.request.body);
+        if (ctx.request && ctx.request.body && ctx.request.body && ctx.request.body.ids.length > 0) {
+            const subscriptions = await SubscriptionService.getSubscriptionsByIds(ctx.request.body.ids);
+            ctx.body = { data: subscriptions };
+        } else {
+            ctx.body = { data: [] };
+        }
+    }
+
+    static async findUserSubscriptions(ctx) {
+        const { userId } = ctx.params;
+        const application = ctx.query.application || 'gfw';
+        const env = ctx.query.env || 'production';
+        logger.info(`[SubscriptionsRouter] Getting all subscriptions for user with id`, userId);
+        const subscriptions = await SubscriptionService.getSubscriptionsForUser(userId, application, env);
+        ctx.body = { data: subscriptions };
+    }
+
 }
 
 const isAdmin = async (ctx, next) => {
@@ -331,5 +350,7 @@ router.patch('/:id', isLoggedUserRequired, subscriptionExists(true), Subscriptio
 router.delete('/:id', isLoggedUserRequired, subscriptionExists(true), SubscriptionsRouter.deleteSubscription);
 router.post('/notify-updates/:dataset', SubscriptionsRouter.notifyUpdates);
 router.post('/check-hook', SubscriptionsRouter.checkHook);
+router.get('/user/:userId', SubscriptionsRouter.findUserSubscriptions);
+router.post('/find-by-ids', SubscriptionsRouter.findByIds);
 
 module.exports = router;

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -259,11 +259,8 @@ class SubscriptionsRouter {
     }
 
     static async findUserSubscriptions(ctx) {
-        const { userId } = ctx.params;
-        ctx.assert(ctx.query.application, 400, 'Application required');
-        ctx.assert(ctx.query.env, 400, 'Environment required');
-        logger.info(`[SubscriptionsRouter] Getting all subscriptions for user with id`, userId);
-        ctx.body = await SubscriptionService.getSubscriptionsForUser(userId, ctx.query.application, ctx.query.env);
+        logger.info(`[SubscriptionsRouter] Getting all subscriptions for user with id`, ctx.params.userId);
+        ctx.body = await SubscriptionService.getSubscriptionsForUser(ctx.params.userId, ctx.query.application, ctx.query.env);
     }
 
 }

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -336,6 +336,17 @@ const isLoggedUserRequired = async (ctx, next) => {
     await next();
 };
 
+const isMicroservice = async (ctx, next) => {
+    const loggedUser = SubscriptionsRouter.getUser(ctx);
+
+    if (loggedUser.id !== 'microservice') {
+        ctx.throw(403, 'Not authorized');
+        return;
+    }
+
+    await next();
+};
+
 router.post('/', SubscriptionsRouter.createSubscription);
 router.get('/', isLoggedUserRequired, SubscriptionsRouter.getSubscriptions);
 router.get('/statistics', isAdmin, SubscriptionsRouter.statistics);
@@ -350,7 +361,7 @@ router.patch('/:id', isLoggedUserRequired, subscriptionExists(true), Subscriptio
 router.delete('/:id', isLoggedUserRequired, subscriptionExists(true), SubscriptionsRouter.deleteSubscription);
 router.post('/notify-updates/:dataset', SubscriptionsRouter.notifyUpdates);
 router.post('/check-hook', SubscriptionsRouter.checkHook);
-router.get('/user/:userId', SubscriptionsRouter.findUserSubscriptions);
-router.post('/find-by-ids', SubscriptionsRouter.findByIds);
+router.get('/user/:userId', isMicroservice, SubscriptionsRouter.findUserSubscriptions);
+router.post('/find-by-ids', isMicroservice, SubscriptionsRouter.findByIds);
 
 module.exports = router;

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -264,8 +264,7 @@ class SubscriptionsRouter {
         const application = ctx.query.application || 'gfw';
         const env = ctx.query.env || 'production';
         logger.info(`[SubscriptionsRouter] Getting all subscriptions for user with id`, userId);
-        const subscriptions = await SubscriptionService.getSubscriptionsForUser(userId, application, env);
-        ctx.body = { data: subscriptions };
+        ctx.body = await SubscriptionService.getSubscriptionsForUser(userId, application, env);
     }
 
 }

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -128,8 +128,12 @@ class SubscriptionService {
         return subscriptions;
     }
 
-    static async getSubscriptionsForUser(userId, application, env) {
-        const subscriptions = await Subscription.find({ userId, application, env }).exec();
+    static async getSubscriptionsForUser(userId, application = undefined, env = undefined) {
+        const filter = { userId };
+        if (application) filter.application = application;
+        if (env) filter.env = env;
+
+        const subscriptions = await Subscription.find(filter).exec();
         return SubscriptionSerializer.serialize(subscriptions);
     }
 

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const logger = require('logger');
+const mongoose = require('mongoose');
 const Subscription = require('models/subscription');
 const SubscriptionSerializer = require('serializers/subscriptionSerializer');
 
@@ -30,7 +31,9 @@ class SubscriptionService {
 
     static async createSubscription(data) {
         logger.info('Creating subscription with data ', data);
-        data.userId = data.loggedUser.id;
+        data.userId = data.loggedUser.id === 'microservice'
+            ? data.userId || data.loggedUser.id
+            : data.loggedUser.id;
 
         const subscriptionFormatted = SubscriptionService.formatSubscription(data);
         logger.debug('Creating subscription ', subscriptionFormatted);
@@ -139,6 +142,10 @@ class SubscriptionService {
         }).exec();
 
         return SubscriptionSerializer.serialize(subscriptions);
+    }
+
+    static async getSubscriptionsByIds(ids) {
+        return Subscription.find({ _id: { $in: ids.map((id) => mongoose.Types.ObjectId(id)) } });
     }
 
 }

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -31,10 +31,7 @@ class SubscriptionService {
 
     static async createSubscription(data) {
         logger.info('Creating subscription with data ', data);
-        data.userId = data.loggedUser.id === 'microservice'
-            ? data.userId || data.loggedUser.id
-            : data.loggedUser.id;
-
+        data.userId = (data.loggedUser.id === 'microservice') ? data.userId : data.loggedUser.id;
         const subscriptionFormatted = SubscriptionService.formatSubscription(data);
         logger.debug('Creating subscription ', subscriptionFormatted);
         delete subscriptionFormatted.createdAt;
@@ -87,7 +84,7 @@ class SubscriptionService {
     }
 
     static async updateSubscription(id, data) {
-        const subscription = await Subscription.where({ _id: id }).findOne();
+        const subscription = await Subscription.findById(id);
         let attributes = _.omitBy(data, _.isNil);
         attributes = _.omit(attributes, 'loggedUser');
         _.each(attributes, (value, attribute) => {
@@ -132,12 +129,7 @@ class SubscriptionService {
     }
 
     static async getSubscriptionsForUser(userId, application, env) {
-        const subscriptions = await Subscription.find({
-            userId,
-            application,
-            env
-        }).exec();
-
+        const subscriptions = await Subscription.find({ userId, application, env }).exec();
         return SubscriptionSerializer.serialize(subscriptions);
     }
 
@@ -146,7 +138,8 @@ class SubscriptionService {
             .filter(mongoose.Types.ObjectId.isValid)
             .map((id) => mongoose.Types.ObjectId(id));
 
-        return Subscription.find({ _id: { $in: idsToFind } });
+        const subscriptions = await Subscription.find({ _id: { $in: idsToFind } });
+        return SubscriptionSerializer.serialize(subscriptions);
     }
 
 }

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -145,7 +145,11 @@ class SubscriptionService {
     }
 
     static async getSubscriptionsByIds(ids) {
-        return Subscription.find({ _id: { $in: ids.map((id) => mongoose.Types.ObjectId(id)) } });
+        const idsToFind = ids
+            .filter(mongoose.Types.ObjectId.isValid)
+            .map((id) => mongoose.Types.ObjectId(id));
+
+        return Subscription.find({ _id: { $in: idsToFind } });
     }
 
 }

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -86,11 +86,8 @@ class SubscriptionService {
         );
     }
 
-    static async updateSubscription(id, userId, data) {
-        const subscription = await Subscription.where({
-            _id: id,
-            userId
-        }).findOne();
+    static async updateSubscription(id, data) {
+        const subscription = await Subscription.where({ _id: id }).findOne();
         let attributes = _.omitBy(data, _.isNil);
         attributes = _.omit(attributes, 'loggedUser');
         _.each(attributes, (value, attribute) => {

--- a/app/test/e2e/subscriptions-find-by-ids.spec.js
+++ b/app/test/e2e/subscriptions-find-by-ids.spec.js
@@ -40,9 +40,6 @@ describe('Find subscriptions by ids tests', () => {
 
         const superAdminResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.SUPERADMIN });
         superAdminResponse.status.should.equal(401);
-
-        const msResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.MICROSERVICE });
-        msResponse.status.should.equal(200);
     });
 
     it('Finding subscriptions providing wrong type data (non-string ids) returns a 200 OK response with no data', async () => {
@@ -53,10 +50,11 @@ describe('Find subscriptions by ids tests', () => {
         response.body.should.have.property('data').with.lengthOf(0);
     });
 
-    it('Finding subscriptions by ids without providing ids should return a 200 OK response with no data', async () => {
+    it('Finding subscriptions by ids without providing ids returns 400 Bad Request requiring the ids', async () => {
         const response = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.MICROSERVICE });
-        response.status.should.equal(200);
-        response.body.should.have.property('data').with.lengthOf(0);
+        response.status.should.equal(400);
+        response.body.should.have.property('errors').with.lengthOf(1);
+        response.body.errors[0].should.have.property('detail').and.be.equal('Ids not provided.');
     });
 
     it('Finding subscriptions by ids providing invalid ids should return a 200 OK response with no data', async () => {
@@ -76,6 +74,7 @@ describe('Find subscriptions by ids tests', () => {
             .send({ ids: [subscriptionOne.id, subscriptionTwo.id], loggedUser: ROLES.MICROSERVICE });
         response.status.should.equal(200);
         response.body.should.have.property('data').with.lengthOf(2);
+        response.body.data.map((e) => e.id).should.have.members([subscriptionOne.id.toString(), subscriptionTwo.id.toString()]);
     });
 
     it('Finding subscriptions by ids providing a mix of valid and invalid ids should return a 200 OK response with only the subscription data for valid ids', async () => {
@@ -87,6 +86,7 @@ describe('Find subscriptions by ids tests', () => {
             .send({ ids: [subscriptionOne.id, subscriptionTwo.id, 'invalid-id'], loggedUser: ROLES.MICROSERVICE });
         response.status.should.equal(200);
         response.body.should.have.property('data').with.lengthOf(2);
+        response.body.data.map((e) => e.id).should.have.members([subscriptionOne.id.toString(), subscriptionTwo.id.toString()]);
     });
 
     afterEach(async () => {

--- a/app/test/e2e/subscriptions-find-by-ids.spec.js
+++ b/app/test/e2e/subscriptions-find-by-ids.spec.js
@@ -25,21 +25,21 @@ describe('Find subscriptions by ids tests', () => {
         await Subscription.deleteMany({}).exec();
     });
 
-    it('Finding subscriptions is only allowed when the request is performed by a micro service, failing with 403 Forbidden otherwise', async () => {
+    it('Finding subscriptions is only allowed when the request is performed by a micro service, failing with 401 Unauthorized otherwise', async () => {
         const noTokenResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send();
-        noTokenResponse.status.should.equal(403);
+        noTokenResponse.status.should.equal(401);
 
         const userResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.USER });
-        userResponse.status.should.equal(403);
+        userResponse.status.should.equal(401);
 
         const managerResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.MANAGER });
-        managerResponse.status.should.equal(403);
+        managerResponse.status.should.equal(401);
 
         const adminResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.ADMIN });
-        adminResponse.status.should.equal(403);
+        adminResponse.status.should.equal(401);
 
         const superAdminResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.SUPERADMIN });
-        superAdminResponse.status.should.equal(403);
+        superAdminResponse.status.should.equal(401);
 
         const msResponse = await requester.post(`/api/v1/subscriptions/find-by-ids`).send({ loggedUser: ROLES.MICROSERVICE });
         msResponse.status.should.equal(200);

--- a/app/test/e2e/subscriptions-find-by-ids.spec.js
+++ b/app/test/e2e/subscriptions-find-by-ids.spec.js
@@ -1,0 +1,79 @@
+/* eslint-disable no-unused-vars,no-undef */
+const nock = require('nock');
+const chai = require('chai');
+const Subscription = require('models/subscription');
+const { createSubscription } = require('./utils/helpers');
+const { ROLES } = require('./utils/test.constants');
+const { getTestServer } = require('./utils/test-server');
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+chai.should();
+
+let requester;
+
+describe('Find subscriptions by ids tests', () => {
+
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+
+        await Subscription.deleteMany({}).exec();
+    });
+
+    it('Finding subscriptions providing wrong type data (non-string ids) returns a 200 OK response with no data', async () => {
+        const response = await requester
+            .post(`/api/v1/subscriptions/find-by-ids`)
+            .send({ ids: [{}] });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(0);
+    });
+
+    it('Finding subscriptions by ids without providing ids should return a 200 OK response with no data', async () => {
+        const response = await requester.post(`/api/v1/subscriptions/find-by-ids`).send();
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(0);
+    });
+
+    it('Finding subscriptions by ids providing invalid ids should return a 200 OK response with no data', async () => {
+        const response = await requester
+            .post(`/api/v1/subscriptions/find-by-ids`)
+            .send({ ids: ['non-existing-id'] });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(0);
+    });
+
+    it('Finding subscriptions by ids providing existing ids should return a 200 OK response with the subscription data', async () => {
+        const subscriptionOne = await new Subscription(createSubscription(ROLES.USER.id)).save();
+        const subscriptionTwo = await new Subscription(createSubscription(ROLES.USER.id)).save();
+
+        const response = await requester
+            .post(`/api/v1/subscriptions/find-by-ids`)
+            .send({ ids: [subscriptionOne.id, subscriptionTwo.id] });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(2);
+    });
+
+    it('Finding subscriptions by ids providing a mix of valid and invalid ids should return a 200 OK response with only the subscription data for valid ids', async () => {
+        const subscriptionOne = await new Subscription(createSubscription(ROLES.USER.id)).save();
+        const subscriptionTwo = await new Subscription(createSubscription(ROLES.USER.id)).save();
+
+        const response = await requester
+            .post(`/api/v1/subscriptions/find-by-ids`)
+            .send({ ids: [subscriptionOne.id, subscriptionTwo.id, 'invalid-id'] });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(2);
+    });
+
+    afterEach(async () => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+
+        await Subscription.deleteMany({}).exec();
+    });
+});

--- a/app/test/e2e/subscriptions-find-for-user.spec.js
+++ b/app/test/e2e/subscriptions-find-for-user.spec.js
@@ -25,35 +25,35 @@ describe('Find subscriptions for user tests', () => {
         await Subscription.deleteMany({}).exec();
     });
 
-    it('Finding subscriptions for users is only allowed when the request is performed by a micro service, failing with 403 Forbidden otherwise', async () => {
+    it('Finding subscriptions for users is only allowed when the request is performed by a micro service, failing with 401 Unauthorized otherwise', async () => {
         const noTokenResponse = await requester
             .get(`/api/v1/subscriptions/user/1`)
             .send();
-        noTokenResponse.status.should.equal(403);
+        noTokenResponse.status.should.equal(401);
 
         const userResponse = await requester
             .get(`/api/v1/subscriptions/user/1`)
             .query({ loggedUser: JSON.stringify(ROLES.USER) })
             .send();
-        userResponse.status.should.equal(403);
+        userResponse.status.should.equal(401);
 
         const managerResponse = await requester
             .get(`/api/v1/subscriptions/user/1`)
             .query({ loggedUser: JSON.stringify(ROLES.MANAGER) })
             .send();
-        managerResponse.status.should.equal(403);
+        managerResponse.status.should.equal(401);
 
         const adminResponse = await requester
             .get(`/api/v1/subscriptions/user/1`)
             .query({ loggedUser: JSON.stringify(ROLES.ADMIN) })
             .send();
-        adminResponse.status.should.equal(403);
+        adminResponse.status.should.equal(401);
 
         const superAdminResponse = await requester
             .get(`/api/v1/subscriptions/user/1`)
             .query({ loggedUser: JSON.stringify(ROLES.SUPERADMIN) })
             .send();
-        superAdminResponse.status.should.equal(403);
+        superAdminResponse.status.should.equal(401);
     });
 
     it('Finding subscriptions for a user that does not have associated subscriptions returns a 200 OK response with no data', async () => {

--- a/app/test/e2e/subscriptions-find-for-user.spec.js
+++ b/app/test/e2e/subscriptions-find-for-user.spec.js
@@ -26,40 +26,50 @@ describe('Find subscriptions for user tests', () => {
     });
 
     it('Finding subscriptions for users is only allowed when the request is performed by a micro service, failing with 401 Unauthorized otherwise', async () => {
-        const noTokenResponse = await requester
-            .get(`/api/v1/subscriptions/user/1`)
-            .send();
+        const noTokenResponse = await requester.get(`/api/v1/subscriptions/user/1`).send();
         noTokenResponse.status.should.equal(401);
 
-        const userResponse = await requester
-            .get(`/api/v1/subscriptions/user/1`)
-            .query({ loggedUser: JSON.stringify(ROLES.USER) })
-            .send();
+        const userResponse = await requester.get(`/api/v1/subscriptions/user/1`).query({ loggedUser: JSON.stringify(ROLES.USER) }).send();
         userResponse.status.should.equal(401);
 
-        const managerResponse = await requester
-            .get(`/api/v1/subscriptions/user/1`)
-            .query({ loggedUser: JSON.stringify(ROLES.MANAGER) })
-            .send();
+        const managerResponse = await requester.get(`/api/v1/subscriptions/user/1`).query({ loggedUser: JSON.stringify(ROLES.MANAGER) }).send();
         managerResponse.status.should.equal(401);
 
-        const adminResponse = await requester
-            .get(`/api/v1/subscriptions/user/1`)
-            .query({ loggedUser: JSON.stringify(ROLES.ADMIN) })
-            .send();
+        const adminResponse = await requester.get(`/api/v1/subscriptions/user/1`).query({ loggedUser: JSON.stringify(ROLES.ADMIN) }).send();
         adminResponse.status.should.equal(401);
 
-        const superAdminResponse = await requester
-            .get(`/api/v1/subscriptions/user/1`)
-            .query({ loggedUser: JSON.stringify(ROLES.SUPERADMIN) })
-            .send();
+        const superAdminResponse = await requester.get(`/api/v1/subscriptions/user/1`).query({ loggedUser: JSON.stringify(ROLES.SUPERADMIN) }).send();
         superAdminResponse.status.should.equal(401);
+    });
+
+    it('Finding subscriptions without providing an application query param returns 400 Bad Request', async () => {
+        const response = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .send();
+        response.status.should.equal(400);
+        response.body.should.have.property('errors').with.lengthOf(1);
+        response.body.errors[0].should.have.property('detail').and.be.equal('Application required');
+    });
+
+    it('Finding subscriptions without providing an environment query param returns 400 Bad Request', async () => {
+        const response = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .query({ application: 'gfw', loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .send();
+        response.status.should.equal(400);
+        response.body.should.have.property('errors').with.lengthOf(1);
+        response.body.errors[0].should.have.property('detail').and.be.equal('Environment required');
     });
 
     it('Finding subscriptions for a user that does not have associated subscriptions returns a 200 OK response with no data', async () => {
         const response = await requester
             .get(`/api/v1/subscriptions/user/1`)
-            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .query({
+                loggedUser: JSON.stringify(ROLES.MICROSERVICE),
+                application: 'gfw',
+                env: 'production',
+            })
             .send();
         response.status.should.equal(200);
         response.body.should.have.property('data').with.lengthOf(0);
@@ -72,7 +82,11 @@ describe('Find subscriptions for user tests', () => {
 
         const response = await requester
             .get(`/api/v1/subscriptions/user/${ROLES.USER.id}`)
-            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .query({
+                loggedUser: JSON.stringify(ROLES.MICROSERVICE),
+                application: 'gfw',
+                env: 'production',
+            })
             .send();
         response.status.should.equal(200);
         response.body.should.have.property('data').with.lengthOf(2);

--- a/app/test/e2e/subscriptions-find-for-user.spec.js
+++ b/app/test/e2e/subscriptions-find-for-user.spec.js
@@ -1,0 +1,89 @@
+/* eslint-disable no-unused-expressions,no-unused-vars,no-undef */
+const nock = require('nock');
+const chai = require('chai');
+const Subscription = require('models/subscription');
+const { createSubscription } = require('./utils/helpers');
+const { ROLES } = require('./utils/test.constants');
+const { getTestServer } = require('./utils/test-server');
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+chai.should();
+
+let requester;
+
+describe('Find subscriptions for user tests', () => {
+
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+
+        await Subscription.deleteMany({}).exec();
+    });
+
+    it('Finding subscriptions for users is only allowed when the request is performed by a micro service, failing with 403 Forbidden otherwise', async () => {
+        const noTokenResponse = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .send();
+        noTokenResponse.status.should.equal(403);
+
+        const userResponse = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .query({ loggedUser: JSON.stringify(ROLES.USER) })
+            .send();
+        userResponse.status.should.equal(403);
+
+        const managerResponse = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .query({ loggedUser: JSON.stringify(ROLES.MANAGER) })
+            .send();
+        managerResponse.status.should.equal(403);
+
+        const adminResponse = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .query({ loggedUser: JSON.stringify(ROLES.ADMIN) })
+            .send();
+        adminResponse.status.should.equal(403);
+
+        const superAdminResponse = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .query({ loggedUser: JSON.stringify(ROLES.SUPERADMIN) })
+            .send();
+        superAdminResponse.status.should.equal(403);
+    });
+
+    it('Finding subscriptions for a user that does not have associated subscriptions returns a 200 OK response with no data', async () => {
+        const response = await requester
+            .get(`/api/v1/subscriptions/user/1`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .send();
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(0);
+    });
+
+    it('Finding subscriptions for users by ids providing existing ids should return a 200 OK response with the subscription data', async () => {
+        await new Subscription(createSubscription(ROLES.USER.id)).save();
+        await new Subscription(createSubscription(ROLES.USER.id)).save();
+        await new Subscription(createSubscription('123')).save();
+
+        const response = await requester
+            .get(`/api/v1/subscriptions/user/${ROLES.USER.id}`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .send();
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(2);
+        response.body.data.every((subscription) => subscription.attributes.userId === ROLES.USER.id).should.be.true;
+    });
+
+    afterEach(async () => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+
+        await Subscription.deleteMany({}).exec();
+    });
+});

--- a/app/test/e2e/utils/test.constants.js
+++ b/app/test/e2e/utils/test.constants.js
@@ -218,6 +218,27 @@ const ROLES = {
                 'data4sdgs'
             ]
         }
+    },
+    SUPERADMIN: {
+        id: '1a10d7c6e0a37126601fd7a6',
+        role: 'SUPERADMIN',
+        provider: 'local',
+        email: 'user@control-tower.org',
+        name: 'test super admin',
+        extraUserData: {
+            apps: [
+                'rw',
+                'gfw',
+                'gfw-climate',
+                'prep',
+                'aqueduct',
+                'forest-atlas',
+                'data4sdgs'
+            ]
+        }
+    },
+    MICROSERVICE: {
+        id: 'microservice'
     }
 };
 


### PR DESCRIPTION
This PR is required for the correct function of this PR: https://github.com/gfw-api/gfw-area/pull/35

Corresponding docs PR: https://github.com/resource-watch/doc-api/pull/113

## What does this PR add?

This PR adds 2 endpoints to the GFW Subscription API MS: one that finds subscriptions by providing an array of ids, and another to find all subscriptions that belong to a user with the provided userId.

Both endpoints can only be called by other MSs.