### PR TITLE
Add endpoint to find all subscriptions for all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 16/03/2020
+
+- Add endpoint to find all subscriptions for all users - restricted to usage by other MSs.
+
 # v1.1.0
 
 ## 28/02/2020

--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -57,6 +57,15 @@
             "path": "/api/v1/subscriptions/find-by-ids"
         }]
     }, {
+        "url": "/v1/subscriptions/admin/find-all",
+        "method": "GET",
+        "authenticated": true,
+        "endpoints": [{
+            "method": "GET",
+            "baseUrl": "#(service.uri)",
+            "path": "/api/v1/subscriptions/admin/find-all"
+        }]
+    }, {
         "url": "/v1/subscriptions/user/:userId",
         "method": "GET",
         "authenticated": true,

--- a/app/microservice/register.json
+++ b/app/microservice/register.json
@@ -57,13 +57,13 @@
             "path": "/api/v1/subscriptions/find-by-ids"
         }]
     }, {
-        "url": "/v1/subscriptions/admin/find-all",
+        "url": "/v1/subscriptions/find-all",
         "method": "GET",
         "authenticated": true,
         "endpoints": [{
             "method": "GET",
             "baseUrl": "#(service.uri)",
-            "path": "/api/v1/subscriptions/admin/find-all"
+            "path": "/api/v1/subscriptions/find-all"
         }]
     }, {
         "url": "/v1/subscriptions/user/:userId",

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -356,6 +356,7 @@ const validateLoggedUserOrMicroserviceAuth = async (ctx, next) => {
 
 router.post('/', SubscriptionsRouter.createSubscription);
 router.get('/', validateLoggedUserAuth, SubscriptionsRouter.getSubscriptions);
+router.get('/find-all', validateMicroserviceAuth, SubscriptionsRouter.findAllSubscriptions);
 router.get('/statistics', isAdmin, SubscriptionsRouter.statistics);
 router.get('/statistics-group', isAdmin, SubscriptionsRouter.statisticsGroup);
 router.get('/statistics-by-user', isAdmin, SubscriptionsRouter.statisticsByUser);
@@ -369,7 +370,6 @@ router.delete('/:id', validateLoggedUserOrMicroserviceAuth, subscriptionExists(t
 router.post('/notify-updates/:dataset', SubscriptionsRouter.notifyUpdates);
 router.post('/check-hook', SubscriptionsRouter.checkHook);
 router.get('/user/:userId', validateMicroserviceAuth, SubscriptionsRouter.findUserSubscriptions);
-router.get('/admin/find-all', validateMicroserviceAuth, SubscriptionsRouter.findAllSubscriptions);
 router.post('/find-by-ids', validateMicroserviceAuth, SubscriptionsRouter.findByIds);
 
 module.exports = router;

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -263,6 +263,11 @@ class SubscriptionsRouter {
         ctx.body = await SubscriptionService.getSubscriptionsForUser(ctx.params.userId, ctx.query.application, ctx.query.env);
     }
 
+    static async findAllSubscriptions(ctx) {
+        logger.info(`[SubscriptionsRouter] Getting ALL subscriptions`);
+        ctx.body = await SubscriptionService.getAllSubscriptions(ctx.query.application, ctx.query.env);
+    }
+
 }
 
 const isAdmin = async (ctx, next) => {
@@ -364,6 +369,7 @@ router.delete('/:id', validateLoggedUserOrMicroserviceAuth, subscriptionExists(t
 router.post('/notify-updates/:dataset', SubscriptionsRouter.notifyUpdates);
 router.post('/check-hook', SubscriptionsRouter.checkHook);
 router.get('/user/:userId', validateMicroserviceAuth, SubscriptionsRouter.findUserSubscriptions);
+router.get('/admin/find-all', validateMicroserviceAuth, SubscriptionsRouter.findAllSubscriptions);
 router.post('/find-by-ids', validateMicroserviceAuth, SubscriptionsRouter.findByIds);
 
 module.exports = router;

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -128,6 +128,15 @@ class SubscriptionService {
         return subscriptions;
     }
 
+    static async getAllSubscriptions(application = undefined, env = undefined) {
+        const filter = {};
+        if (application) filter.application = application;
+        if (env) filter.env = env;
+
+        const subscriptions = await Subscription.find(filter).exec();
+        return SubscriptionSerializer.serialize(subscriptions);
+    }
+
     static async getSubscriptionsForUser(userId, application = undefined, env = undefined) {
         const filter = { userId };
         if (application) filter.application = application;

--- a/app/test/e2e/subscriptions-find-all.spec.js
+++ b/app/test/e2e/subscriptions-find-all.spec.js
@@ -1,0 +1,126 @@
+/* eslint-disable no-unused-expressions,no-unused-vars,no-undef */
+const nock = require('nock');
+const chai = require('chai');
+const Subscription = require('models/subscription');
+const { createSubscription } = require('./utils/helpers');
+const { ROLES } = require('./utils/test.constants');
+const { getTestServer } = require('./utils/test-server');
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+chai.should();
+
+let requester;
+
+describe('Find all subscriptions tests', () => {
+
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+
+        await Subscription.deleteMany({}).exec();
+    });
+
+    it('Finding all subscriptions is only allowed when the request is performed by a micro service, failing with 401 Unauthorized otherwise', async () => {
+        const noTokenResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).send();
+        noTokenResponse.status.should.equal(401);
+
+        const userResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.USER) }).send();
+        userResponse.status.should.equal(401);
+
+        const managerResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.MANAGER) }).send();
+        managerResponse.status.should.equal(401);
+
+        const adminResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.ADMIN) }).send();
+        adminResponse.status.should.equal(401);
+
+        const superAdminResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.SUPERADMIN) }).send();
+        superAdminResponse.status.should.equal(401);
+    });
+
+    it('Finding all subscriptions when there are no existing subscriptions returns a 200 OK response with no data', async () => {
+        const response = await requester
+            .get(`/api/v1/subscriptions/admin/find-all`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .send();
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(0);
+    });
+
+    it('Finding all subscriptions should return a 200 OK response with all the subscriptions', async () => {
+        await new Subscription(createSubscription(ROLES.USER.id)).save();
+        await new Subscription(createSubscription(ROLES.MANAGER.id)).save();
+        await new Subscription(createSubscription(ROLES.ADMIN.id)).save();
+        await new Subscription(createSubscription(ROLES.SUPERADMIN.id)).save();
+        await new Subscription(createSubscription('123')).save();
+
+        const response = await requester
+            .get(`/api/v1/subscriptions/admin/find-all`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
+            .send();
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(5);
+    });
+
+    it('Finding all subscriptions allows filtering by application query param, returns 200 OK with the correct data', async () => {
+        const gfwSub1 = await new Subscription(createSubscription(ROLES.USER.id, null, { application: 'gfw' })).save();
+        const gfwSub2 = await new Subscription(createSubscription(ROLES.MANAGER.id, null, { application: 'gfw' })).save();
+        const rwSub1 = await new Subscription(createSubscription(ROLES.USER.id, null, { application: 'rw' })).save();
+        const rwSub2 = await new Subscription(createSubscription(ROLES.MANAGER.id, null, { application: 'rw' })).save();
+
+        const response1 = await requester
+            .get(`/api/v1/subscriptions/admin/find-all`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), application: 'gfw' })
+            .send();
+        response1.status.should.equal(200);
+        response1.body.should.have.property('data').with.lengthOf(2);
+        response1.body.data.map((el) => el.id).should.contain(gfwSub1.id);
+        response1.body.data.map((el) => el.id).should.contain(gfwSub2.id);
+
+        const response2 = await requester
+            .get(`/api/v1/subscriptions/admin/find-all`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), application: 'rw' })
+            .send();
+        response2.status.should.equal(200);
+        response2.body.should.have.property('data').with.lengthOf(2);
+        response2.body.data.map((el) => el.id).should.contain(rwSub1.id);
+        response2.body.data.map((el) => el.id).should.contain(rwSub2.id);
+    });
+
+    it('Finding subscriptions allows filtering by environment query param, returns 200 OK with the correct data', async () => {
+        const prodSub1 = await new Subscription(createSubscription(ROLES.USER.id, null, { env: 'production' })).save();
+        const prodSub2 = await new Subscription(createSubscription(ROLES.MANAGER.id, null, { env: 'production' })).save();
+        const stgSub1 = await new Subscription(createSubscription(ROLES.USER.id, null, { env: 'staging' })).save();
+        const stgSub2 = await new Subscription(createSubscription(ROLES.MANAGER.id, null, { env: 'staging' })).save();
+
+        const response1 = await requester
+            .get(`/api/v1/subscriptions/admin/find-all`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), env: 'production' })
+            .send();
+        response1.status.should.equal(200);
+        response1.body.should.have.property('data').with.lengthOf(2);
+        response1.body.data.map((el) => el.id).should.contain(prodSub1.id);
+        response1.body.data.map((el) => el.id).should.contain(prodSub2.id);
+
+        const response2 = await requester
+            .get(`/api/v1/subscriptions/admin/find-all`)
+            .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), env: 'staging' })
+            .send();
+        response2.status.should.equal(200);
+        response2.body.should.have.property('data').with.lengthOf(2);
+        response2.body.data.map((el) => el.id).should.contain(stgSub1.id);
+        response2.body.data.map((el) => el.id).should.contain(stgSub2.id);
+    });
+
+    afterEach(async () => {
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+
+        await Subscription.deleteMany({}).exec();
+    });
+});

--- a/app/test/e2e/subscriptions-find-all.spec.js
+++ b/app/test/e2e/subscriptions-find-all.spec.js
@@ -26,25 +26,25 @@ describe('Find all subscriptions tests', () => {
     });
 
     it('Finding all subscriptions is only allowed when the request is performed by a micro service, failing with 401 Unauthorized otherwise', async () => {
-        const noTokenResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).send();
+        const noTokenResponse = await requester.get(`/api/v1/subscriptions/find-all`).send();
         noTokenResponse.status.should.equal(401);
 
-        const userResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.USER) }).send();
+        const userResponse = await requester.get(`/api/v1/subscriptions/find-all`).query({ loggedUser: JSON.stringify(ROLES.USER) }).send();
         userResponse.status.should.equal(401);
 
-        const managerResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.MANAGER) }).send();
+        const managerResponse = await requester.get(`/api/v1/subscriptions/find-all`).query({ loggedUser: JSON.stringify(ROLES.MANAGER) }).send();
         managerResponse.status.should.equal(401);
 
-        const adminResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.ADMIN) }).send();
+        const adminResponse = await requester.get(`/api/v1/subscriptions/find-all`).query({ loggedUser: JSON.stringify(ROLES.ADMIN) }).send();
         adminResponse.status.should.equal(401);
 
-        const superAdminResponse = await requester.get(`/api/v1/subscriptions/admin/find-all`).query({ loggedUser: JSON.stringify(ROLES.SUPERADMIN) }).send();
+        const superAdminResponse = await requester.get(`/api/v1/subscriptions/find-all`).query({ loggedUser: JSON.stringify(ROLES.SUPERADMIN) }).send();
         superAdminResponse.status.should.equal(401);
     });
 
     it('Finding all subscriptions when there are no existing subscriptions returns a 200 OK response with no data', async () => {
         const response = await requester
-            .get(`/api/v1/subscriptions/admin/find-all`)
+            .get(`/api/v1/subscriptions/find-all`)
             .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
             .send();
         response.status.should.equal(200);
@@ -59,7 +59,7 @@ describe('Find all subscriptions tests', () => {
         await new Subscription(createSubscription('123')).save();
 
         const response = await requester
-            .get(`/api/v1/subscriptions/admin/find-all`)
+            .get(`/api/v1/subscriptions/find-all`)
             .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE) })
             .send();
         response.status.should.equal(200);
@@ -73,7 +73,7 @@ describe('Find all subscriptions tests', () => {
         const rwSub2 = await new Subscription(createSubscription(ROLES.MANAGER.id, null, { application: 'rw' })).save();
 
         const response1 = await requester
-            .get(`/api/v1/subscriptions/admin/find-all`)
+            .get(`/api/v1/subscriptions/find-all`)
             .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), application: 'gfw' })
             .send();
         response1.status.should.equal(200);
@@ -82,7 +82,7 @@ describe('Find all subscriptions tests', () => {
         response1.body.data.map((el) => el.id).should.contain(gfwSub2.id);
 
         const response2 = await requester
-            .get(`/api/v1/subscriptions/admin/find-all`)
+            .get(`/api/v1/subscriptions/find-all`)
             .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), application: 'rw' })
             .send();
         response2.status.should.equal(200);
@@ -98,7 +98,7 @@ describe('Find all subscriptions tests', () => {
         const stgSub2 = await new Subscription(createSubscription(ROLES.MANAGER.id, null, { env: 'staging' })).save();
 
         const response1 = await requester
-            .get(`/api/v1/subscriptions/admin/find-all`)
+            .get(`/api/v1/subscriptions/find-all`)
             .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), env: 'production' })
             .send();
         response1.status.should.equal(200);
@@ -107,7 +107,7 @@ describe('Find all subscriptions tests', () => {
         response1.body.data.map((el) => el.id).should.contain(prodSub2.id);
 
         const response2 = await requester
-            .get(`/api/v1/subscriptions/admin/find-all`)
+            .get(`/api/v1/subscriptions/find-all`)
             .query({ loggedUser: JSON.stringify(ROLES.MICROSERVICE), env: 'staging' })
             .send();
         response2.status.should.equal(200);


### PR DESCRIPTION
This PR adds a new endpoint `admin/find-all` _(restricted to usage by other MSs)_ that finds and retrieves all subscriptions in the service.

This endpoint will be used by v2 areas router of `gfw-area` when fetching all areas with a filter `all=true`.

Associated docs PR: https://github.com/resource-watch/doc-api/pull/130