### PR TITLE
Fixes for GLAD email parameters

### DIFF
--- a/app/src/presenters/gladPresenter.js
+++ b/app/src/presenters/gladPresenter.js
@@ -98,8 +98,10 @@ class GLADPresenter {
             results.week_end = endDate.format('DD/MM/YYYY');
             results.glad_count = alerts.data.reduce((acc, curr) => acc + curr.alert__count, 0);
             results.alert_count = alerts.data.reduce((acc, curr) => acc + curr.alert__count, 0);
-            results.download_csv = `${config.get('apiGateway.externalUrl')}/glad-alerts/download/?period=${startDate.format('YYYY-MM-DD')},${endDate.format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=${geostoreId}&format=csv`;
-            results.download_json = `${config.get('apiGateway.externalUrl')}/glad-alerts/download/?period=${startDate.format('YYYY-MM-DD')},${endDate.format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=${geostoreId}&format=json`;
+            results.downloadUrls = {
+                csv: `${config.get('apiGateway.externalUrl')}/glad-alerts/download/?period=${startDate.format('YYYY-MM-DD')},${endDate.format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=${geostoreId}&format=csv`,
+                json: `${config.get('apiGateway.externalUrl')}/glad-alerts/download/?period=${startDate.format('YYYY-MM-DD')},${endDate.format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=${geostoreId}&format=json`,
+            };
 
             // Calculate alerts grouped by area types
             let intactForestAlerts = 0;

--- a/app/src/presenters/gladPresenter.js
+++ b/app/src/presenters/gladPresenter.js
@@ -144,15 +144,6 @@ class GLADPresenter {
                 other: otherAlerts,
             };
 
-            results.glad_alerts = {
-                intact_forest: intactForestAlerts,
-                primary_forest: primaryForestAlerts,
-                peat: peatAlerts,
-                protected_areas: protectedAreasAlerts,
-                plantations: plantationAlerts,
-                other: otherAlerts,
-            };
-
             // Finding standard deviation of alert values
             const lastYearAlerts = await ctRegisterMicroservice.requestToMicroservice({ uri: lastYearURI, method: 'GET', json: true });
             const lastYearAverage = _.mean(lastYearAlerts.data.map((al) => al.alert__count));

--- a/app/test/e2e/glad-alerts-emails.spec.js
+++ b/app/test/e2e/glad-alerts-emails.spec.js
@@ -107,14 +107,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },
@@ -199,14 +191,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },
@@ -290,14 +274,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },
@@ -385,14 +361,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },
@@ -480,14 +448,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },
@@ -575,14 +535,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },
@@ -670,14 +622,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },
@@ -765,14 +709,6 @@ describe('GLAD alert emails', () => {
                         other: 11
                     });
                     jsonMessage.data.should.have.property('glad_count').and.equal(51);
-                    jsonMessage.data.should.have.property('glad_alerts').and.deep.equal({
-                        intact_forest: 6,
-                        primary_forest: 7,
-                        peat: 8,
-                        protected_areas: 9,
-                        plantations: 10,
-                        other: 11
-                    });
                     jsonMessage.data.should.have.property('alerts').and.have.length(6).and.deep.equal([
                         { alert_type: 'GLAD', date: '10/10/2019 00:10 UTC' },
                         { alert_type: 'GLAD', date: '11/10/2019 00:10 UTC' },

--- a/app/test/e2e/glad-alerts-emails.spec.js
+++ b/app/test/e2e/glad-alerts-emails.spec.js
@@ -126,8 +126,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('Custom Area');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal('http://staging.globalforestwatch.org/my-gfw?lang=en');
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=en`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(5);
                     break;
                 case 'subscriptions-stats':
@@ -210,8 +211,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('Custom Area');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal(`http://staging.globalforestwatch.org/my-gfw?lang=fr`);
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=fr`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(5);
                     break;
                 case 'subscriptions-stats':
@@ -293,8 +295,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('Custom Area');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal('http://staging.globalforestwatch.org/my-gfw?lang=zh');
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=zh`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=423e5dfb0448e692f97b590c61f45f22&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(5);
                     break;
                 case 'subscriptions-stats':
@@ -380,8 +383,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('ISO Code: IDN');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal('http://staging.globalforestwatch.org/my-gfw?lang=en');
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=en`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(78746908);
                     break;
                 case 'subscriptions-stats':
@@ -467,8 +471,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('ISO Code: IDN, ID1: 3');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal('http://staging.globalforestwatch.org/my-gfw?lang=en');
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=en`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(78746908);
                     break;
                 case 'subscriptions-stats':
@@ -554,8 +559,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('ISO Code: BRA, ID1: 1, ID2: 1');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal('http://staging.globalforestwatch.org/my-gfw?lang=en');
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=en`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(78746908);
                     break;
                 case 'subscriptions-stats':
@@ -641,8 +647,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('WDPA ID: 1');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal('http://staging.globalforestwatch.org/my-gfw?lang=en');
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=en`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(78746908);
                     break;
                 case 'subscriptions-stats':
@@ -728,8 +735,9 @@ describe('GLAD alert emails', () => {
                     jsonMessage.data.should.have.property('selected_area').and.equal('Custom Area');
                     jsonMessage.data.should.have.property('subscriptions_url').and.equal('http://staging.globalforestwatch.org/my-gfw?lang=en');
                     jsonMessage.data.should.have.property('unsubscribe_url').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/subscriptions/${subscriptionOne.id}/unsubscribe?redirect=true&lang=en`);
-                    jsonMessage.data.should.have.property('download_csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
-                    jsonMessage.data.should.have.property('download_json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
+                    jsonMessage.data.should.have.property('downloadUrls');
+                    jsonMessage.data.downloadUrls.should.have.property('csv').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=csv`);
+                    jsonMessage.data.downloadUrls.should.have.property('json').and.equal(`${process.env.API_GATEWAY_EXTERNAL_URL}/glad-alerts/download/?period=${moment(beginDate).format('YYYY-MM-DD')},${moment(endDate).format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=f98f505878dcee72a2e92e7510a07d6f&format=json`);
                     jsonMessage.data.should.have.property('value').and.equal(78746908);
                     break;
                 case 'subscriptions-stats':


### PR DESCRIPTION
- remove duplicate `download_csv` and `download_json` params
- removing `glad_alerts` object since it is a duplicate of `priority_areas`