### PR TITLE
Fix/encode map state for alert service url

### DIFF
--- a/app/src/services/alertUrlService.js
+++ b/app/src/services/alertUrlService.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const btoa = require('btoa');
 
 const BASE_URL = config.get('gfw.flagshipUrl');
 const GADM36_DATASET = config.get('layers.gadm36BoundariesDataset');
@@ -8,7 +9,7 @@ const GADM36_LAYER_2 = config.get('layers.gadm36BoundariesLayer2');
 const qs = require('qs');
 const moment = require('moment');
 
-const endocdeStateForUrl = state => btoa(JSON.stringify(state));
+const endocdeStateForUrl = (state) => btoa(JSON.stringify(state));
 
 class AlertUrlService {
 

--- a/app/src/services/alertUrlService.js
+++ b/app/src/services/alertUrlService.js
@@ -8,6 +8,8 @@ const GADM36_LAYER_2 = config.get('layers.gadm36BoundariesLayer2');
 const qs = require('qs');
 const moment = require('moment');
 
+const endocdeStateForUrl = state => btoa(JSON.stringify(state));
+
 class AlertUrlService {
 
     static generate(subscription, layer, begin, end) {
@@ -30,7 +32,7 @@ class AlertUrlService {
 
         const queryForUrl = {
             lang: subscription.language || 'en',
-            map: {
+            map: endocdeStateForUrl({
                 canBound: true,
                 ...layer.datasetId && layer.layerId && {
                     datasets: [
@@ -56,10 +58,10 @@ class AlertUrlService {
                         }
                     ]
                 }
-            },
-            mainMap: {
+            }),
+            mainMap: endocdeStateForUrl({
                 showAnalysis: true
-            }
+            })
         };
 
         return `${BASE_URL}/map/${pathname}?${qs.stringify(queryForUrl)}`;

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "aws-sdk": "^2.90.0",
+    "btoa": "^1.2.1",
     "bunyan": "^1.8.12",
     "cartodb": "^0.5.1",
     "config": "1.19.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,6 +572,11 @@ bson@^1.1.1, bson@~1.1.1:
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.3.tgz#aa82cb91f9a453aaa060d6209d0675114a8154d3"
   integrity sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==
 
+btoa@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/btoa/-/btoa-1.2.1.tgz#01a9909f8b2c93f6bf680ba26131eb30f7fa3d73"
+  integrity sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==
+
 buffer@^4.9.1:
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"


### PR DESCRIPTION
When send a user to the map, we must make sure to encode the map state for the map and mainMap objects.