### PR TITLE
Use correct datasets for fetching GLAD alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
-## 29/05/2020
+## 05/06/2020
 
 - Add endpoint for testing subscription email alerts for GLAD alerts and VIIRS Fires. [#172772548](https://www.pivotaltracker.com/story/show/172772548)
+
+- Update the datasets used by GLAD alert emails to the correct ones. [#173192978](https://www.pivotaltracker.com/story/show/173192978)
 
 # v.1.4.2
 

--- a/app/src/presenters/gladPresenter.js
+++ b/app/src/presenters/gladPresenter.js
@@ -77,12 +77,10 @@ class GLADPresenter {
         try {
             const startDate = moment(begin);
             const endDate = moment(end);
-            const geostoreId = await GeostoreService.getGeostoreIdFromSubscriptionParams(subscription.params);
-
-            const alerts = await GLADAlertsService.getAnalysisInPeriodForGeostore(
+            const alerts = await GLADAlertsService.getAnalysisInPeriodForSubscription(
                 startDate.format('YYYY-MM-DD'),
                 endDate.format('YYYY-MM-DD'),
-                geostoreId
+                subscription.params
             );
 
             results.alerts = alerts.map((el) => ({
@@ -96,6 +94,7 @@ class GLADPresenter {
             results.week_end = endDate.format('DD/MM/YYYY');
             results.glad_count = alerts.reduce((acc, curr) => acc + curr.alert__count, 0);
             results.alert_count = alerts.reduce((acc, curr) => acc + curr.alert__count, 0);
+            const geostoreId = await GeostoreService.getGeostoreIdFromSubscriptionParams(subscription.params);
             results.downloadUrls = {
                 csv: `${config.get('apiGateway.externalUrl')}/glad-alerts/download/?period=${startDate.format('YYYY-MM-DD')},${endDate.format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=${geostoreId}&format=csv`,
                 json: `${config.get('apiGateway.externalUrl')}/glad-alerts/download/?period=${startDate.format('YYYY-MM-DD')},${endDate.format('YYYY-MM-DD')}&gladConfirmOnly=False&aggregate_values=False&aggregate_by=False&geostore=${geostoreId}&format=json`,
@@ -147,10 +146,10 @@ class GLADPresenter {
             // Finding standard deviation of alert values
             const lastYearStartDate = moment(begin).subtract('1', 'y');
             const lastYearEndDate = moment(end).subtract('1', 'y');
-            const lastYearAlerts = await GLADAlertsService.getAnalysisInPeriodForGeostore(
+            const lastYearAlerts = await GLADAlertsService.getAnalysisInPeriodForSubscription(
                 lastYearStartDate.format('YYYY-MM-DD'),
                 lastYearEndDate.format('YYYY-MM-DD'),
-                geostoreId
+                subscription.params
             );
 
             const lastYearAverage = _.mean(lastYearAlerts.map((al) => al.alert__count));

--- a/app/src/services/analysisService.js
+++ b/app/src/services/analysisService.js
@@ -5,7 +5,6 @@ const JSONAPIDeserializer = require('jsonapi-serializer').Deserializer;
 
 const AnalysisClassifier = require('services/analysisClassifier');
 const GLADAlertsService = require('services/gladAlertsService');
-const GeostoreService = require('services/geostoreService');
 
 const formatDate = (date) => moment(date).format('YYYY-MM-DD');
 
@@ -31,8 +30,7 @@ class AnalysisService {
         try {
             // Override results in the case of glad-alerts
             if (layerSlug === 'glad-alerts') {
-                const geostoreId = await GeostoreService.getGeostoreIdFromSubscriptionParams(subscription.params);
-                return await GLADAlertsService.getAnalysisInPeriodForGeostore(formatDate(begin), formatDate(end), geostoreId);
+                return await GLADAlertsService.getAnalysisInPeriodForSubscription(formatDate(begin), formatDate(end), subscription.params);
             }
 
             const result = await ctRegisterMicroservice.requestToMicroservice({

--- a/app/src/services/gladAlertsService.js
+++ b/app/src/services/gladAlertsService.js
@@ -16,7 +16,7 @@ class GLADAlertsService {
     static getURLInPeriodForGeostore(startDate, endDate, geostoreId) {
         // eslint-disable-next-line max-len
         const sql = `SELECT * FROM data WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}' AND geostore__id = '${geostoreId}' ORDER BY alert__date`;
-        return `/query/${config.get('datasets.gladAlertsDataset')}?sql=${sql}`;
+        return `/query/${config.get('datasets.gladGeostoreDataset')}?sql=${sql}`;
     }
 
     /**

--- a/app/src/services/gladAlertsService.js
+++ b/app/src/services/gladAlertsService.js
@@ -1,11 +1,59 @@
 const config = require('config');
 const logger = require('logger');
 const ctRegisterMicroservice = require('ct-register-microservice-node');
+const GeostoreService = require('services/geostoreService');
 
 class GLADAlertsService {
 
     /**
-     * Gets the alert data for the period and geostore provided.
+     * Returns the URL that should be used to fetch alerts for a subscription related to an ISO.
+     *
+     * @param {string} startDate YYYY-MM-DD formatted date representing the start date of the period.
+     * @param {string} endDate YYYY-MM-DD formatted date representing the end date of the period.
+     * @param {Object} params Params containing the ISO info that should be used.
+     *
+     * @returns {string} The URL that should be used to fetch the alerts.
+     */
+    static getURLInPeriodForISO(startDate, endDate, params = {}) {
+        const { country, region, subregion } = params.iso;
+        let sql = `SELECT * FROM data WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}' `;
+
+        if (country) {
+            sql += `AND iso = '${country}' `;
+        }
+
+        if (region) {
+            sql += `AND adm1 = '${region}' `;
+        }
+
+        if (subregion) {
+            sql += `AND adm2 = '${subregion}' `;
+        }
+
+        sql += ' ORDER BY alert__date';
+
+        return `/query/${config.get('datasets.gladISODataset')}?sql=${sql}`;
+    }
+
+    /**
+     * Returns the URL that should be used to fetch alerts for a subscription related to a WDPA.
+     *
+     * @param {string} startDate YYYY-MM-DD formatted date representing the start date of the period.
+     * @param {string} endDate YYYY-MM-DD formatted date representing the end date of the period.
+     * @param {Object} params Params containing the WDPA info that should be used.
+     *
+     * @returns {string} The URL that should be used to fetch the alerts.
+     */
+    static getURLInPeriodForWDPA(startDate, endDate, params = {}) {
+        const { wdpaid } = params;
+        let sql = `SELECT * FROM data WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}' `;
+        sql += `AND wdpa_protected_area__id = '${wdpaid}'`;
+        sql += ' ORDER BY alert__date';
+        return `/query/${config.get('datasets.gladWDPADataset')}?sql=${sql}`;
+    }
+
+    /**
+     * Returns the URL that should be used to fetch alerts for a subscription related to a geostore.
      *
      * @param {string} startDate YYYY-MM-DD formatted date representing the start date of the period.
      * @param {string} endDate YYYY-MM-DD formatted date representing the end date of the period.
@@ -14,23 +62,24 @@ class GLADAlertsService {
      * @returns {string} The URL that should be used to fetch the alerts.
      */
     static getURLInPeriodForGeostore(startDate, endDate, geostoreId) {
-        // eslint-disable-next-line max-len
-        const sql = `SELECT * FROM data WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}' AND geostore__id = '${geostoreId}' ORDER BY alert__date`;
+        const sql = `SELECT * FROM data WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}' `
+            + `AND geostore__id = '${geostoreId}' ORDER BY alert__date`;
         return `/query/${config.get('datasets.gladGeostoreDataset')}?sql=${sql}`;
     }
 
-    /**
-     * Gets the alert data for the period and geostore provided.
-     *
-     * @param {string} startDate YYYY-MM-DD formatted date representing the start date of the period.
-     * @param {string} endDate YYYY-MM-DD formatted date representing the end date of the period.
-     * @param {string} geostoreId The ID of the geostore.
-     *
-     * @returns {Promise<[Object]>} A promise resolving into an array of alerts.
-     */
-    static async getAnalysisInPeriodForGeostore(startDate, endDate, geostoreId) {
-        logger.info('Entering GLAD analysis endpoint with params', startDate, endDate, geostoreId);
-        const uri = GLADAlertsService.getURLInPeriodForGeostore(startDate, endDate, geostoreId);
+    static async getAnalysisInPeriodForSubscription(startDate, endDate, params) {
+        let uri;
+        logger.info('Entering GLAD analysis endpoint with params', startDate, endDate, params);
+
+        if (params && params.iso) {
+            uri = GLADAlertsService.getURLInPeriodForISO(startDate, endDate, params);
+        } else if (params && params.wdpaid) {
+            uri = GLADAlertsService.getURLInPeriodForWDPA(startDate, endDate, params);
+        } else {
+            const geostoreId = await GeostoreService.getGeostoreIdFromSubscriptionParams(params);
+            uri = GLADAlertsService.getURLInPeriodForGeostore(startDate, endDate, geostoreId);
+        }
+
         const response = await ctRegisterMicroservice.requestToMicroservice({ uri, method: 'GET', json: true });
         return response.data;
     }

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -170,6 +170,14 @@ class SubscriptionService {
         return SubscriptionSerializer.serialize(subscriptions);
     }
 
+    static isSubscriptionISO(subscription) {
+        return subscription && subscription.params && subscription.params.iso;
+    }
+
+    static isSubscriptionWDPA(subscription) {
+        return subscription && subscription.params && subscription.params.wdpaid;
+    }
+
 }
 
 module.exports = SubscriptionService;

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -170,14 +170,6 @@ class SubscriptionService {
         return SubscriptionSerializer.serialize(subscriptions);
     }
 
-    static isSubscriptionISO(subscription) {
-        return subscription && subscription.params && subscription.params.iso;
-    }
-
-    static isSubscriptionWDPA(subscription) {
-        return subscription && subscription.params && subscription.params.wdpaid;
-    }
-
 }
 
 module.exports = SubscriptionService;

--- a/app/test/e2e/glad-alerts-emails.spec.js
+++ b/app/test/e2e/glad-alerts-emails.spec.js
@@ -353,8 +353,8 @@ describe('GLAD alert emails', () => {
         )).save();
 
         const { beginDate, endDate } = bootstrapGLADAlertTest();
-        createMockAlertsQuery(3);
-        createMockGeostore('/v2/geostore/admin/IDN', 2);
+        createMockAlertsQuery(3, config.get('datasets.gladISODataset'));
+        createMockGeostore('/v2/geostore/admin/IDN');
 
         redisClient.on('message', (channel, message) => {
             const jsonMessage = JSON.parse(message);
@@ -448,8 +448,8 @@ describe('GLAD alert emails', () => {
         )).save();
 
         const { beginDate, endDate } = bootstrapGLADAlertTest();
-        createMockAlertsQuery(3);
-        createMockGeostore('/v2/geostore/admin/IDN/3', 2);
+        createMockAlertsQuery(3, config.get('datasets.gladISODataset'));
+        createMockGeostore('/v2/geostore/admin/IDN/3');
 
         redisClient.on('message', (channel, message) => {
             const jsonMessage = JSON.parse(message);
@@ -543,8 +543,8 @@ describe('GLAD alert emails', () => {
         )).save();
 
         const { beginDate, endDate } = bootstrapGLADAlertTest();
-        createMockAlertsQuery(3);
-        createMockGeostore('/v2/geostore/admin/BRA/1/1', 2);
+        createMockAlertsQuery(3, config.get('datasets.gladISODataset'));
+        createMockGeostore('/v2/geostore/admin/BRA/1/1');
 
         redisClient.on('message', (channel, message) => {
             const jsonMessage = JSON.parse(message);
@@ -638,8 +638,8 @@ describe('GLAD alert emails', () => {
         )).save();
 
         const { beginDate, endDate } = bootstrapGLADAlertTest();
-        createMockAlertsQuery(3);
-        createMockGeostore('/v2/geostore/wdpa/1', 2);
+        createMockAlertsQuery(3, config.get('datasets.gladWDPADataset'));
+        createMockGeostore('/v2/geostore/wdpa/1');
 
         redisClient.on('message', (channel, message) => {
             const jsonMessage = JSON.parse(message);
@@ -734,7 +734,7 @@ describe('GLAD alert emails', () => {
 
         const { beginDate, endDate } = bootstrapGLADAlertTest();
         createMockAlertsQuery(3);
-        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 2);
+        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 4);
 
         redisClient.on('message', (channel, message) => {
             const jsonMessage = JSON.parse(message);
@@ -826,7 +826,7 @@ describe('GLAD alert emails', () => {
         )).save();
 
         const { beginDate, endDate } = bootstrapGLADAlertTest();
-        createMockAlertsQuery(1, { data: [] });
+        createMockAlertsQuery(1, undefined, { data: [] });
 
         redisClient.on('message', (channel, message) => {
             const jsonMessage = JSON.parse(message);

--- a/app/test/e2e/utils/mock.js
+++ b/app/test/e2e/utils/mock.js
@@ -46,7 +46,7 @@ const createMockLatestDataset = (datasetID, date) => nock(process.env.CT_URL)
 
 const createMockAlertsQuery = (times = 1, overrideData = {}) => {
     nock(process.env.CT_URL)
-        .get(`/v1/query/${config.get('datasets.gladAlertsDataset')}`)
+        .get(`/v1/query/${config.get('datasets.gladGeostoreDataset')}`)
         .query(() => true)
         .times(times)
         .reply(200, {
@@ -218,11 +218,11 @@ const createMockAlertsQuery = (times = 1, overrideData = {}) => {
             meta: {
                 cloneUrl: {
                     http_method: 'POST',
-                    url: `/v1/dataset/${config.get('datasets.gladAlertsDataset')}/clone`,
+                    url: `/v1/dataset/${config.get('datasets.gladGeostoreDataset')}/clone`,
                     body: {
                         dataset: {
                             // eslint-disable-next-line max-len
-                            datasetUrl: `/v1/query/${config.get('datasets.gladAlertsDataset')}?sql=SELECT%20%2A%20FROM%20data%20WHERE%20alert__date%20%3E%20%272019-10-01%27%20AND%20alert__date%20%3C%20%272020-01-01%27%20AND%20geostore__id%20%3D%20%27test%27`,
+                            datasetUrl: `/v1/query/${config.get('datasets.gladGeostoreDataset')}?sql=SELECT%20%2A%20FROM%20data%20WHERE%20alert__date%20%3E%20%272019-10-01%27%20AND%20alert__date%20%3C%20%272020-01-01%27%20AND%20geostore__id%20%3D%20%27test%27`,
                             application: [
                                 'your',
                                 'apps'

--- a/app/test/e2e/utils/mock.js
+++ b/app/test/e2e/utils/mock.js
@@ -44,9 +44,10 @@ const createMockLatestDataset = (datasetID, date) => nock(process.env.CT_URL)
     .get(`/v1/${datasetID}/latest`)
     .reply(200, { data: { date } });
 
-const createMockAlertsQuery = (times = 1, overrideData = {}) => {
+const createMockAlertsQuery = (times = 1, datasetId = undefined, overrideData = {}) => {
+    const id = datasetId || config.get('datasets.gladGeostoreDataset');
     nock(process.env.CT_URL)
-        .get(`/v1/query/${config.get('datasets.gladGeostoreDataset')}`)
+        .get(`/v1/query/${id}`)
         .query(() => true)
         .times(times)
         .reply(200, {
@@ -218,11 +219,11 @@ const createMockAlertsQuery = (times = 1, overrideData = {}) => {
             meta: {
                 cloneUrl: {
                     http_method: 'POST',
-                    url: `/v1/dataset/${config.get('datasets.gladGeostoreDataset')}/clone`,
+                    url: `/v1/dataset/${id}/clone`,
                     body: {
                         dataset: {
                             // eslint-disable-next-line max-len
-                            datasetUrl: `/v1/query/${config.get('datasets.gladGeostoreDataset')}?sql=SELECT%20%2A%20FROM%20data%20WHERE%20alert__date%20%3E%20%272019-10-01%27%20AND%20alert__date%20%3C%20%272020-01-01%27%20AND%20geostore__id%20%3D%20%27test%27`,
+                            datasetUrl: `/v1/query/${id}?sql=SELECT%20%2A%20FROM%20data%20WHERE%20alert__date%20%3E%20%272019-10-01%27%20AND%20alert__date%20%3C%20%272020-01-01%27%20AND%20geostore__id%20%3D%20%27test%27`,
                             application: [
                                 'your',
                                 'apps'

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -40,6 +40,9 @@
     "loadCron": "LOAD_CRON"
   },
   "datasets": {
-    "gladAlertsDataset": "NEW_GLAD_ALERTS_DATASET_ID"
+    "gladISODataset": "NEW_GLAD_ISO_DATASET_ID",
+    "gladWDPADataset": "NEW_GLAD_WDPA_DATASET_ID",
+    "gladGeostoreDataset": "NEW_GLAD_ALERTS_DATASET_ID",
+    "viirsAlertsDataset": "NEW_VIIRS_ALERTS_DATASET_ID"
   }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,6 +1,9 @@
 {
   "datasets": {
-    "gladAlertsDataset": "64f17d8a-49ab-4132-b6bc-55dfa48ce3d0"
+    "gladISODataset": "61170ad0-9d6a-4347-8e58-9b551eeb341e",
+    "gladWDPADataset": "bb2a69f1-c3ca-44e3-bd3c-0d6b9fb30169",
+    "gladGeostoreDataset": "69f279f5-c5e3-4856-bd8b-2b5eceaef56a",
+    "viirsAlertsDataset": "e17593fd-fdcf-40c5-8e6e-c437c9fc15a2"
   },
   "layers": {
     "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",

--- a/config/mongoose.js
+++ b/config/mongoose.js
@@ -8,7 +8,7 @@ const mongooseOptions = {
     readPreference: 'secondaryPreferred', // Has MongoDB prefer secondary servers for read operations.
     appname: 'subscriptions', // Displays the app name in MongoDB logs, for ease of debug
     serverSelectionTimeoutMS: 10000, // Number of milliseconds the underlying MongoDB driver has to pick a server
-    loggerLevel: config.get('logger.level') // Logger level to pass to the MongoDB driver
+    // loggerLevel: config.get('logger.level') // Logger level to pass to the MongoDB driver
 };
 
 module.exports = mongooseOptions;

--- a/config/prod.json
+++ b/config/prod.json
@@ -6,7 +6,10 @@
     "dirLogFile": null
   },
   "datasets": {
-    "gladAlertsDataset": "9be3bf63-97fc-4bb0-b913-775ccae3cf9e"
+    "gladISODataset": "61170ad0-9d6a-4347-8e58-9b551eeb341e",
+    "gladWDPADataset": "bb2a69f1-c3ca-44e3-bd3c-0d6b9fb30169",
+    "gladGeostoreDataset": "69f279f5-c5e3-4856-bd8b-2b5eceaef56a",
+    "viirsAlertsDataset": "e17593fd-fdcf-40c5-8e6e-c437c9fc15a2"
   },
   "layers": {
     "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",

--- a/config/staging.json
+++ b/config/staging.json
@@ -6,7 +6,10 @@
     "dirLogFile": null
   },
   "datasets": {
-    "gladAlertsDataset": "64f17d8a-49ab-4132-b6bc-55dfa48ce3d0"
+    "gladISODataset": "61170ad0-9d6a-4347-8e58-9b551eeb341e",
+    "gladWDPADataset": "bb2a69f1-c3ca-44e3-bd3c-0d6b9fb30169",
+    "gladGeostoreDataset": "69f279f5-c5e3-4856-bd8b-2b5eceaef56a",
+    "viirsAlertsDataset": "e17593fd-fdcf-40c5-8e6e-c437c9fc15a2"
   },
   "layers": {
     "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",

--- a/config/test.json
+++ b/config/test.json
@@ -9,7 +9,10 @@
     "loadCron": false
   },
   "datasets": {
-    "gladAlertsDataset": "64f17d8a-49ab-4132-b6bc-55dfa48ce3d0"
+    "gladISODataset": "61170ad0-9d6a-4347-8e58-9b551eeb341e",
+    "gladWDPADataset": "bb2a69f1-c3ca-44e3-bd3c-0d6b9fb30169",
+    "gladGeostoreDataset": "69f279f5-c5e3-4856-bd8b-2b5eceaef56a",
+    "viirsAlertsDataset": "e17593fd-fdcf-40c5-8e6e-c437c9fc15a2"
   },
   "layers": {
     "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",


### PR DESCRIPTION
This PR updates the GLAD alerts service to use the correct datasets when fetching the GLAD alerts for the intended period. The new logic is as follows:

For every dataset (GLADS, VIIRS, TCL) we have a set of tables:

- **GADM**: If the subscription refers to an admin you query the GADM using the columns `iso`, `adm1`, and `adm2` for SELECTing the location (datasetId for production: `61170ad0-9d6a-4347-8e58-9b551eeb341e`)
- **WDPA**: If the subscription refers to a protected area you query WDPA using the column `wdpa__id` for SELECTing the location (datasetId for production: `bb2a69f1-c3ca-44e3-bd3c-0d6b9fb30169`)
- **GEOSTORE**: If the subscription refers to anything else you go to geostore using `geostore__id` for SELECTing the location (datasetId for production: `69f279f5-c5e3-4856-bd8b-2b5eceaef56a`)

This was the result of [this Slack thread](https://vizzuality.slack.com/archives/C0633T0LC/p1590998802001600) and the dataset ids were fetched from [this spreadsheet](https://docs.google.com/spreadsheets/u/1/d/1X0g-cqjfGuFs0p2JRaR8x1PwowYV6zFIO0LFFXL4P1U/edit#gid=1095138209).
