### PR TITLE
Add redirect=false flag to disable redirection in re-send confirmation endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
+# v.1.5.1
+
+## 03/07/2020
+
+- Add `redirect=false` via query param to disable redirection in re-send confirmation endpoint.
+
 # v.1.5.0
 
 ## 05/06/2020
 
 - Add endpoint for testing subscription email alerts for GLAD alerts and VIIRS Fires. [#172772548](https://www.pivotaltracker.com/story/show/172772548)
-
 - Update the datasets used by GLAD alert emails to the correct ones. [#173192978](https://www.pivotaltracker.com/story/show/173192978)
-
 - Add cron schedule entry for GLAD alerts. [#173192978](https://www.pivotaltracker.com/story/show/173192978)
 
 # v.1.4.2

--- a/app/src/routes/api/v1/subscription.router.js
+++ b/app/src/routes/api/v1/subscription.router.js
@@ -139,7 +139,14 @@ class SubscriptionsRouter {
         try {
             SubscriptionService.sendConfirmation(subscription);
             logger.info(`Redirect to: ${config.get('gfw.flagshipUrl')}/my_gfw/subscriptions`);
-            ctx.redirect(`${config.get('gfw.flagshipUrl')}/my_gfw/subscriptions`);
+
+            // Allows redirect=false flag to be provided, but defaults to applying the redirect
+            if (ctx.query.redirect !== 'false') {
+                ctx.redirect(`${config.get('gfw.flagshipUrl')}/my_gfw/subscriptions`);
+                return;
+            }
+
+            ctx.body = subscription;
         } catch (err) {
             logger.error(err);
         }

--- a/app/test/e2e/send-confirm.spec.js
+++ b/app/test/e2e/send-confirm.spec.js
@@ -109,6 +109,22 @@ describe('Send confirmation endpoint', () => {
         process.on('unhandledRejection', (err) => should.fail(err));
     });
 
+    it('Providing redirect=false as query param disables the redirection (happy case)', async () => {
+        const createdSubscription = await new Subscription(createSubscription(ROLES.USER.id)).save();
+        const response = await subscription
+            .get(`/${createdSubscription._id}/send_confirmation`)
+            .query({
+                loggedUser: JSON.stringify(ROLES.USER),
+                application: 'rw',
+                redirect: false,
+            })
+            .send();
+        response.status.should.equal(200);
+        response.body._id.should.equal(createdSubscription._id.toString());
+
+        process.on('unhandledRejection', (err) => should.fail(err));
+    });
+
     afterEach(async () => {
         process.removeAllListeners('unhandledRejection');
         this.channel.removeAllListeners('message');


### PR DESCRIPTION
This PR adds the possibility of disabling redirection when requesting a new confirmation email for a given subscription. This disabling is done by providing `redirect=false` via query parameter. The default behavior of redirecting the request to the GFW flagship has been kept as is.