### PR TITLE
Sanitize subscription language when an invalid language is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v.1.6.2
+
+## 22/07/2020
+
+- Sanitize language of the subscription when providing an invalid language (supported languages are `en`, `fr`, `es`, `pt`, `zh` and `id`).
+
 # v.1.6.1
 
 ## 15/07/2020

--- a/app/src/services/subscriptionService.js
+++ b/app/src/services/subscriptionService.js
@@ -9,6 +9,10 @@ const UrlService = require('services/urlService');
 
 class SubscriptionService {
 
+    static getSupportedLanguages() {
+        return ['en', 'fr', 'es', 'pt', 'zh', 'id'];
+    }
+
     static formatSubscription(subscription) {
         if (!subscription) {
             return {};
@@ -33,6 +37,12 @@ class SubscriptionService {
     static async createSubscription(data) {
         logger.info('Creating subscription with data ', data);
         data.userId = (data.loggedUser.id === 'microservice') ? data.userId : data.loggedUser.id;
+
+        // Sanitize subscription language
+        if (!SubscriptionService.getSupportedLanguages().includes(data.language)) {
+            data.language = 'en';
+        }
+
         const subscriptionFormatted = SubscriptionService.formatSubscription(data);
         logger.debug('Creating subscription ', subscriptionFormatted);
         delete subscriptionFormatted.createdAt;
@@ -91,6 +101,11 @@ class SubscriptionService {
         _.each(attributes, (value, attribute) => {
             subscription[attribute] = value;
         });
+
+        // Sanitize subscription language
+        if (!SubscriptionService.getSupportedLanguages().includes(subscription.language)) {
+            subscription.language = 'en';
+        }
 
         await subscription.save();
 

--- a/app/test/e2e/subscription-update.spec.js
+++ b/app/test/e2e/subscription-update.spec.js
@@ -158,17 +158,11 @@ describe('Update subscription endpoint', () => {
         data.attributes.should.deep.equal(expectedAttributes);
 
         const subscriptionFromDB = await Subscription.findOne({ _id: subscription._id });
-        const expectedSubscription = {
-            ...subscription._doc,
-            ...SUBSCRIPTION_TO_UPDATE,
-            __v: 1
-        };
-        const actualSubscription = {
-            ...subscriptionFromDB._doc,
-            createdAt: subscriptionFromDB.createdAt.toISOString(),
-        };
-
-        actualSubscription.should.deep.equal(expectedSubscription);
+        subscriptionFromDB._doc.should.deep.equal({
+            ...subscription.toJSON(),
+            ...updateData,
+            language: 'en',
+        });
     });
 
     afterEach(async () => {

--- a/app/test/e2e/subscriptions-create.spec.js
+++ b/app/test/e2e/subscriptions-create.spec.js
@@ -160,16 +160,16 @@ describe('Create subscriptions tests', () => {
 
     it('Create a subscription with the basic required fields with application = "test" should return a 200, create a subscription and emit a redis message(happy case)', async () => {
         this.channel.on('message', validRedisMessage({
-            template: 'subscription-confirmation-test-ru',
+            template: 'subscription-confirmation-test-en',
             application: 'gfw',
-            language: 'ru',
+            language: 'en',
         }));
 
         const response = await requester
             .post(`/api/v1/subscriptions`)
             .send({
                 datasets: ['123456789'],
-                language: 'ru',
+                language: 'en',
                 resource: {
                     type: 'EMAIL',
                     content: 'email@address.com'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gfw-subscription-api",
-  "version": "1.5.0",
+  "version": "1.6.2",
   "description": "Global Forest Watch - Subscription API",
   "main": "app/index.js",
   "scripts": {


### PR DESCRIPTION
This PR applies sanitization of the language of the subscription when providing an invalid language (supported languages are `en`, `fr`, `es`, `pt`, `zh` and `id`). This sanitization is applied in POST and PATCH requests, and if an invalid language is provided, the default value `en` is set.