### PR TITLE
Update local docker setup so it builds and registers with the Control Tower correctly

### DIFF
--- a/dev.env.sample
+++ b/dev.env.sample
@@ -1,5 +1,5 @@
-CT_URL=http://mymychine:9000
-LOCAL_URL=http://mymychine:3000
+CT_URL=http://mymachine:9000
+LOCAL_URL=http://mymachine:35725
 API_GATEWAY_URL=http://mymachine:9000
 API_URL=http://mymachine:9000
 API_GATEWAY_EXTERNAL_URL=http://mymachine:9000

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -40,9 +40,8 @@ services:
   mongo:
     image: mongo
     container_name: gfw-subscription-mongo
-    command: --smallfiles
     ports:
-      - "27017"
+      - "27021:27017"
     volumes:
       # in osx the host machine volume directory cannot be under /Users
       # http://stackoverflow.hex1.ru/questions/34390220/how-to-mount-external-volume-for-mongodb-using-docker-compose-and-docker-machine


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Fix typos in sample env
- Allow mongodb to be accessed externally for development purposes