### PR TITLE
get gadm area props from the area service and gadm geostores from data api

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
         patterns: ['./*', '../*'],
       },
     ],
+    '@typescript-eslint/semi': ['error', 'always'],
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'error',
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.4-alpine3.18
+FROM node:20.5-alpine3.18
 MAINTAINER info@vizzuality.com
 
 ENV NAME gfw-subscription-api

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -45,6 +45,7 @@
   "dataApi": {
     "url": "DATA_API_URL",
     "apiKey": "DATA_API_KEY",
-    "origin": "DATA_API_ORIGIN"
+    "origin": "DATA_API_ORIGIN",
+    "gadmVersion": "GADM_VERSION"
   }
 }

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,4 +1,10 @@
 {
+  "logger": {
+    "name": "gfw-subscription-api-DEV",
+    "level": "debug",
+    "toFile": false,
+    "dirLogFile": null
+  },
   "layers": {
     "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",
     "gladAlertLayer": "8e4a527d-1bcd-4a12-82b0-5a108ffec452",

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -22,6 +22,7 @@ services:
       AWS_ACCESS_KEY_ID: "test"
       AWS_SECRET_ACCESS_KEY: "test"
       REQUIRE_API_KEY: true
+      GADM_VERSION: "3.6"
     command: test
     depends_on:
       - mongo

--- a/k8s/dev/deployment.yaml
+++ b/k8s/dev/deployment.yaml
@@ -134,6 +134,8 @@ spec:
                 secretKeyRef:
                   key: REQUIRE_API_KEY
                   name: mssecrets
+            - name: GADM_VERSION
+              value: "3.6"
           image: gfwdockerhub/subscriptions
           imagePullPolicy: Always
           livenessProbe:

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -135,6 +135,8 @@ spec:
                 secretKeyRef:
                   key: REQUIRE_API_KEY
                   name: mssecrets
+            - name: GADM_VERSION
+              value: "3.6"
           image: gfwdockerhub/subscriptions
           imagePullPolicy: Always
           livenessProbe:

--- a/k8s/staging/deployment.yaml
+++ b/k8s/staging/deployment.yaml
@@ -134,6 +134,8 @@ spec:
                 secretKeyRef:
                   key: REQUIRE_API_KEY
                   name: mssecrets
+            - name: GADM_VERSION
+              value: "3.6"
           image: gfwdockerhub/subscriptions
           imagePullPolicy: Always
           livenessProbe:

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/Vizzuality/gfw-subscription-api#readme",
   "engines": {
-    "node": "~20.4"
+    "node": "~20.5"
   },
   "dependencies": {
     "axios": "^1.4.0",

--- a/src/presenters/gladAllPresenter.ts
+++ b/src/presenters/gladAllPresenter.ts
@@ -6,6 +6,7 @@ import UrlService from 'services/urlService';
 import { AlertResultWithCount, PresenterInterface } from 'presenters/presenter.interface';
 import { ISubscription } from 'models/subscription';
 import { ILayer } from 'models/layer';
+import AreaService from 'services/areaService';
 import GeostoreService from 'services/geostoreService';
 import config from 'config';
 import axios, { AxiosResponse } from 'axios';
@@ -70,24 +71,36 @@ class GLADAllPresenter extends PresenterInterface<GladAllAlertResultType, GladAl
         return `${DATASET_GLAD_ALL_GEOSTORE}?sql=${sql}`;
     }
 
-    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string): string {
+    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'rw' | 'gfw' = 'rw'): string {
         const sql: string = `SELECT latitude, longitude, gfw_integrated_alerts__date, umd_glad_landsat_alerts__confidence, umd_glad_sentinel2_alerts__confidence, `
             + `wur_radd_alerts__confidence, gfw_integrated_alerts__confidence FROM data WHERE gfw_integrated_alerts__date >= '${startDate}' `
             + `AND gfw_integrated_alerts__date <= '${endDate}'`;
-        return `${DATASET_GLAD_ALL_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=rw&geostore_id=${geostoreId}`;
+        return `${DATASET_GLAD_ALL_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
     }
 
     static async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
+        let areaIso: Record<string, any> = {};
+        if (params?.area && params?.iso && params.iso?.country) {
+           const area: Record<string, any> = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
+        }
+
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+        
+        const country: string = iso?.country;
+        const region: string = iso?.region;
+        const subregion: string = iso?.subregion;
+
         if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region && !!params.iso.subregion) {
-            return GLADAllPresenter.#getURLForAdmin2(startDate, endDate, params.iso.country, params.iso.region, params.iso.subregion);
+            return GLADAllPresenter.#getURLForAdmin2(startDate, endDate, country, region, subregion);
         }
 
         if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region) {
-            return GLADAllPresenter.#getURLForAdmin1(startDate, endDate, params.iso.country, params.iso.region);
+            return GLADAllPresenter.#getURLForAdmin1(startDate, endDate, country, region);
         }
 
         if (!!params && !!params.iso && !!params.iso.country) {
-            return GLADAllPresenter.#getURLForAdmin0(startDate, endDate, params.iso.country);
+            return GLADAllPresenter.#getURLForAdmin0(startDate, endDate, country);
         }
 
         if (!!params && !!params.wdpaid) {
@@ -116,8 +129,19 @@ class GLADAllPresenter extends PresenterInterface<GladAllAlertResultType, GladAl
     }
 
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(params);
-        const uri: string = GLADAllPresenter.#getURLForDownload(startDate, endDate, geostoreId);
+        let areaIso: Record<string, any> = {};
+        let area: Record<string, any>;
+        if (params?.area && params?.iso && params.iso?.country) {
+            area = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
+        }
+
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+
+        const updatedParams: Record<string, any> = {...params, iso};
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        const uri: string = GLADAllPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),
@@ -137,7 +161,7 @@ class GLADAllPresenter extends PresenterInterface<GladAllAlertResultType, GladAl
         resultObject.week_of = `${startDate.format('DD MMM')}`;
         resultObject.week_start = startDate.format('DD/MM/YYYY');
         resultObject.week_end = endDate.format('DD/MM/YYYY');
-        const alertCount: number = results.data.reduce((acc: number, curr: GladAllAlertResultType) => acc + curr.alert__count, 0)
+        const alertCount: number = results.data.reduce((acc: number, curr: GladAllAlertResultType) => acc + curr.alert__count, 0);
         resultObject.glad_count = alertCount;
         resultObject.alert_count = alertCount;
 
@@ -197,4 +221,4 @@ class GLADAllPresenter extends PresenterInterface<GladAllAlertResultType, GladAl
 
 }
 
-export default new GLADAllPresenter()
+export default new GLADAllPresenter();

--- a/src/presenters/gladLPresenter.ts
+++ b/src/presenters/gladLPresenter.ts
@@ -89,15 +89,15 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
         const region: string = iso?.region;
         const subregion: string = iso?.subregion;
 
-        if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region && !!params.iso.subregion) {
+        if (country && region && subregion) {
             return GLADLPresenter.#getURLForAdmin2(startDate, endDate, country, region, subregion);
         }
 
-        if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region) {
+        if (country && region) {
             return GLADLPresenter.#getURLForAdmin1(startDate, endDate, country, region);
         }
 
-        if (!!params && !!params.iso && !!params.iso.country) {
+        if (country) {
             return GLADLPresenter.#getURLForAdmin0(startDate, endDate, country);
         }
 

--- a/src/presenters/gladLPresenter.ts
+++ b/src/presenters/gladLPresenter.ts
@@ -78,16 +78,14 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     }
 
     async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
-        let area: Record<string, any> = {};
+        let areaIso: Record<string, any> = {};
         if (params?.area && params?.iso && params.iso?.country) {
-            area = await AreaService.getUserArea(params.area);
+           const area: Record<string, any> = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
         }
-        const iso: Record<string, any> = area?.admin && Object.keys(area.admin).length 
-        ? area.admin 
-        : area?.iso && Object.keys(area.iso).length 
-        ? area.iso 
-        : params.iso;
 
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+        
         const country: string = iso?.country;
         const region: string = iso?.region;
         const subregion: string = iso?.subregion;
@@ -140,17 +138,17 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     }
 
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
-        const area: Record<string, any> = params.area ? await AreaService.getUserArea(params.area) : {};
-        const iso: Record<string, any> = area?.admin && Object.keys(area.admin).length 
-            ? area.admin 
-            : area?.iso && Object.keys(area.iso).length 
-            ? area.iso 
-            : params.iso;
-        
-        
-        const updatedParams: Record<string, any> = {...params, iso};
+        let areaIso: Record<string, any> = {};
+        let area: Record<string, any>;
+        if (params?.area && params?.iso && params.iso?.country) {
+            area = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
+        }
 
-        const geostoreSource: 'rw' | 'gfw' = (iso?.source?.provider === 'gadm' && iso?.source?.version === '4.1') ? 'gfw' : 'rw';
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+
+        const updatedParams: Record<string, any> = {...params, iso};
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
         const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
         const uri: string = GLADLPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
         return {

--- a/src/presenters/gladLPresenter.ts
+++ b/src/presenters/gladLPresenter.ts
@@ -78,10 +78,13 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     }
 
     async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
-        const area: Record<string, any> = params.area ? await AreaService.getUserArea(params.area) : {};
-        const iso: Record<string, any> = area.admin && Object.keys(area.admin).length 
+        let area: Record<string, any> = {};
+        if (params?.area && params?.iso && params.iso?.country) {
+            area = await AreaService.getUserArea(params.area);
+        }
+        const iso: Record<string, any> = area?.admin && Object.keys(area.admin).length 
         ? area.admin 
-        : area.iso && Object.keys(area.iso).length 
+        : area?.iso && Object.keys(area.iso).length 
         ? area.iso 
         : params.iso;
 

--- a/src/presenters/gladLPresenter.ts
+++ b/src/presenters/gladLPresenter.ts
@@ -9,6 +9,7 @@ import GeostoreService from 'services/geostoreService';
 import config from 'config';
 import axios, { AxiosResponse } from 'axios';
 import { GladLPresenterResponse } from 'types/presenterResponse.type';
+import AreaService from 'services/areaService';
 import AlertUrlService from 'services/alertUrlService';
 import UrlService from 'services/urlService';
 
@@ -70,23 +71,34 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
         return `${DATASET_GLAD_L_GEOSTORE}?sql=${sql}`;
     }
 
-    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string): string {
+    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
         const sql: string = `SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence `
             + `FROM data WHERE umd_glad_landsat_alerts__date >= '${startDate}' AND umd_glad_landsat_alerts__date <= '${endDate}'`;
-        return `${DATASET_GLAD_L_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=rw&geostore_id=${geostoreId}`;
+        return `${DATASET_GLAD_L_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
     }
 
     async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
+        const area = params.area ? await AreaService.getUserArea(params.area) : {};
+        const iso = area.admin && Object.keys(area.admin).length 
+        ? area.admin 
+        : area.iso && Object.keys(area.iso).length 
+        ? area.iso 
+        : params.iso;
+
+        const country = iso?.country;
+        const region = iso?.region;
+        const subregion = iso?.subregion;
+
         if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region && !!params.iso.subregion) {
-            return GLADLPresenter.#getURLForAdmin2(startDate, endDate, params.iso.country, params.iso.region, params.iso.subregion);
+            return GLADLPresenter.#getURLForAdmin2(startDate, endDate, country, region, subregion);
         }
 
         if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region) {
-            return GLADLPresenter.#getURLForAdmin1(startDate, endDate, params.iso.country, params.iso.region);
+            return GLADLPresenter.#getURLForAdmin1(startDate, endDate, country, region);
         }
 
         if (!!params && !!params.iso && !!params.iso.country) {
-            return GLADLPresenter.#getURLForAdmin0(startDate, endDate, params.iso.country);
+            return GLADLPresenter.#getURLForAdmin0(startDate, endDate, country);
         }
 
         if (!!params && !!params.wdpaid) {
@@ -125,8 +137,19 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     }
 
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(params);
-        const uri: string = GLADLPresenter.#getURLForDownload(startDate, endDate, geostoreId);
+        const area = params.area ? await AreaService.getUserArea(params.area) : {};
+        const iso = area?.admin && Object.keys(area.admin).length 
+            ? area.admin 
+            : area?.iso && Object.keys(area.iso).length 
+            ? area.iso 
+            : params.iso;
+        
+        
+        const updatedParams = {...params, iso}
+
+        const geostoreSource = (iso?.source?.provider === 'gadm' && iso?.source?.version === '4.1') ? 'gfw' : 'rw'
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        const uri: string = GLADLPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),

--- a/src/presenters/gladLPresenter.ts
+++ b/src/presenters/gladLPresenter.ts
@@ -78,16 +78,16 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     }
 
     async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
-        const area = params.area ? await AreaService.getUserArea(params.area) : {};
-        const iso = area.admin && Object.keys(area.admin).length 
+        const area: Record<string, any> = params.area ? await AreaService.getUserArea(params.area) : {};
+        const iso: Record<string, any> = area.admin && Object.keys(area.admin).length 
         ? area.admin 
         : area.iso && Object.keys(area.iso).length 
         ? area.iso 
         : params.iso;
 
-        const country = iso?.country;
-        const region = iso?.region;
-        const subregion = iso?.subregion;
+        const country: string = iso?.country;
+        const region: string = iso?.region;
+        const subregion: string = iso?.subregion;
 
         if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region && !!params.iso.subregion) {
             return GLADLPresenter.#getURLForAdmin2(startDate, endDate, country, region, subregion);
@@ -137,17 +137,17 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     }
 
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
-        const area = params.area ? await AreaService.getUserArea(params.area) : {};
-        const iso = area?.admin && Object.keys(area.admin).length 
+        const area: Record<string, any> = params.area ? await AreaService.getUserArea(params.area) : {};
+        const iso: Record<string, any> = area?.admin && Object.keys(area.admin).length 
             ? area.admin 
             : area?.iso && Object.keys(area.iso).length 
             ? area.iso 
             : params.iso;
         
         
-        const updatedParams = {...params, iso}
+        const updatedParams: Record<string, any> = {...params, iso};
 
-        const geostoreSource = (iso?.source?.provider === 'gadm' && iso?.source?.version === '4.1') ? 'gfw' : 'rw'
+        const geostoreSource: 'rw' | 'gfw' = (iso?.source?.provider === 'gadm' && iso?.source?.version === '4.1') ? 'gfw' : 'rw';
         const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
         const uri: string = GLADLPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
         return {
@@ -169,7 +169,7 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
         resultObject.week_of = `${startDate.format('DD MMM')}`;
         resultObject.week_start = startDate.format('DD/MM/YYYY');
         resultObject.week_end = endDate.format('DD/MM/YYYY');
-        const alertCount: number = results.data.reduce((acc: number, curr: GladLAlertResultType) => acc + curr.alert__count, 0)
+        const alertCount: number = results.data.reduce((acc: number, curr: GladLAlertResultType) => acc + curr.alert__count, 0);
         resultObject.glad_count = alertCount;
         resultObject.alert_count = alertCount;
 

--- a/src/presenters/gladRaddPresenter.ts
+++ b/src/presenters/gladRaddPresenter.ts
@@ -10,6 +10,7 @@ import config from 'config';
 import axios, { AxiosResponse } from 'axios';
 import { GladRaddAlertResultType } from 'types/alertResult.type';
 import { GladRaddPresenterResponse } from 'types/presenterResponse.type';
+import AreaService from 'services/areaService';
 
 const DATASET_GLAD_RADD_ADM_0: string = '/dataset/gadm__integrated_alerts__iso_daily_alerts/latest/query';
 const DATASET_GLAD_RADD_ADM_1: string = '/dataset/gadm__integrated_alerts__adm1_daily_alerts/latest/query';
@@ -68,23 +69,35 @@ class GLADRaddPresenter extends PresenterInterface<GladRaddAlertResultType, Glad
         return `${DATASET_GLAD_RADD_GEOSTORE}?sql=${sql}`;
     }
 
-    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string): string {
+    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
         const sql: string = `SELECT latitude, longitude, wur_radd_alerts__date, wur_radd_alerts__confidence `
             + `FROM data WHERE wur_radd_alerts__date >= '${startDate}' AND wur_radd_alerts__date <= '${endDate}'`;
-        return `${DATASET_GLAD_RADD_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=rw&geostore_id=${geostoreId}`;
+        return `${DATASET_GLAD_RADD_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
     }
 
     static async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
-        if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region && !!params.iso.subregion) {
-            return GLADRaddPresenter.#getURLForAdmin2(startDate, endDate, params.iso.country, params.iso.region, params.iso.subregion);
+        let areaIso: Record<string, any> = {};
+        if (params?.area && params?.iso && params.iso?.country) {
+           const area: Record<string, any> = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
         }
 
-        if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region) {
-            return GLADRaddPresenter.#getURLForAdmin1(startDate, endDate, params.iso.country, params.iso.region);
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+        
+        const country: string = iso?.country;
+        const region: string = iso?.region;
+        const subregion: string = iso?.subregion;
+
+        if (country && region && subregion) {
+            return GLADRaddPresenter.#getURLForAdmin2(startDate, endDate, country, region, subregion);
         }
 
-        if (!!params && !!params.iso && !!params.iso.country) {
-            return GLADRaddPresenter.#getURLForAdmin0(startDate, endDate, params.iso.country);
+        if (country && region) {
+            return GLADRaddPresenter.#getURLForAdmin1(startDate, endDate, country, region);
+        }
+
+        if (country) {
+            return GLADRaddPresenter.#getURLForAdmin0(startDate, endDate, country);
         }
 
         if (!!params && !!params.wdpaid) {
@@ -113,8 +126,19 @@ class GLADRaddPresenter extends PresenterInterface<GladRaddAlertResultType, Glad
     }
 
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(params);
-        const uri: string = GLADRaddPresenter.#getURLForDownload(startDate, endDate, geostoreId);
+        let areaIso: Record<string, any> = {};
+        let area: Record<string, any>;
+        if (params?.area && params?.iso && params.iso?.country) {
+            area = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
+        }
+
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+
+        const updatedParams: Record<string, any> = {...params, iso};
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        const uri: string = GLADRaddPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),

--- a/src/presenters/gladS2Presenter.ts
+++ b/src/presenters/gladS2Presenter.ts
@@ -10,6 +10,7 @@ import { ILayer } from 'models/layer';
 import { GladS2AlertResultType } from 'types/alertResult.type';
 import GeostoreService from 'services/geostoreService';
 import { GladS2PresenterResponse } from 'types/presenterResponse.type';
+import AreaService from 'services/areaService';
 
 const DATASET_GLAD_S2_ADM_0: string = '/dataset/gadm__integrated_alerts__iso_daily_alerts/latest/query';
 const DATASET_GLAD_S2_ADM_1: string = '/dataset/gadm__integrated_alerts__adm1_daily_alerts/latest/query';
@@ -68,23 +69,35 @@ class GLADS2Presenter extends PresenterInterface<GladS2AlertResultType, GladS2Pr
         return `${DATASET_GLAD_S2_GEOSTORE}?sql=${sql}`;
     }
 
-    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string): string {
+    static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
         const sql: string = `SELECT latitude, longitude, umd_glad_sentinel2_alerts__date, umd_glad_sentinel2_alerts__confidence `
             + `FROM data WHERE umd_glad_sentinel2_alerts__date >= ${startDate} AND umd_glad_sentinel2_alerts__date <= ${endDate}`;
-        return `${DATASET_GLAD_S2_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=rw&geostore_id=${geostoreId}`;
+        return `${DATASET_GLAD_S2_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
     }
 
     static async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
+        let areaIso: Record<string, any> = {};
+        if (params?.area && params?.iso && params.iso?.country) {
+           const area: Record<string, any> = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
+        }
+
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+        
+        const country: string = iso?.country;
+        const region: string = iso?.region;
+        const subregion: string = iso?.subregion;
+ 
         if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region && !!params.iso.subregion) {
-            return GLADS2Presenter.#getURLForAdmin2(startDate, endDate, params.iso.country, params.iso.region, params.iso.subregion);
+            return GLADS2Presenter.#getURLForAdmin2(startDate, endDate, country, region, subregion);
         }
 
         if (!!params && !!params.iso && !!params.iso.country && !!params.iso.region) {
-            return GLADS2Presenter.#getURLForAdmin1(startDate, endDate, params.iso.country, params.iso.region);
+            return GLADS2Presenter.#getURLForAdmin1(startDate, endDate, country, region);
         }
 
         if (!!params && !!params.iso && !!params.iso.country) {
-            return GLADS2Presenter.#getURLForAdmin0(startDate, endDate, params.iso.country);
+            return GLADS2Presenter.#getURLForAdmin0(startDate, endDate, country);
         }
 
         if (!!params && !!params.wdpaid) {
@@ -113,8 +126,19 @@ class GLADS2Presenter extends PresenterInterface<GladS2AlertResultType, GladS2Pr
     }
 
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(params);
-        const uri: string = GLADS2Presenter.#getURLForDownload(startDate, endDate, geostoreId);
+        let areaIso: Record<string, any> = {};
+        let area: Record<string, any>;
+        if (params?.area && params?.iso && params.iso?.country) {
+            area = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
+        }
+
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+
+        const updatedParams: Record<string, any> = {...params, iso};
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        const uri: string = GLADS2Presenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),

--- a/src/presenters/viirsPresenter.ts
+++ b/src/presenters/viirsPresenter.ts
@@ -12,6 +12,7 @@ import GeostoreService from 'services/geostoreService';
 import axios, { AxiosResponse } from 'axios';
 import { ViirsPresenterResponse } from 'types/presenterResponse.type';
 import { ViirsActiveFiresAlertResultType } from 'types/alertResult.type';
+import AreaService from 'services/areaService';
 
 class ViirsPresenter extends PresenterInterface<ViirsActiveFiresAlertResultType, ViirsPresenterResponse> {
 
@@ -96,9 +97,20 @@ class ViirsPresenter extends PresenterInterface<ViirsActiveFiresAlertResultType,
      * @returns {Promise<*>}
      */
     static async getURLInPeriodForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
+        let areaIso: Record<string, any> = {};
+        if (params?.area && params?.iso && params.iso?.country) {
+            const area: Record<string, any> = await AreaService.getUserArea(params.area);
+            areaIso = AreaService.getIsoParams(area);
+        }
+
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+        
+        const country: string = iso?.country;
+
+
         // At least country must be defined to use the ISO dataset
-        if (!!params && !!params.iso && !!params.iso.country) {
-            return ViirsPresenter.#getURLInPeriodForISO(startDate, endDate, params);
+        if (country) {
+            return ViirsPresenter.#getURLInPeriodForISO(startDate, endDate, { iso });
         }
 
         if (!!params && !!params.wdpaid) {
@@ -153,18 +165,30 @@ class ViirsPresenter extends PresenterInterface<ViirsActiveFiresAlertResultType,
         );
     }
 
-    static getURLInPeriodForDownload(startDate: string, endDate: string, geostoreId: string): string {
+    static getURLInPeriodForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
         const sql: string = `SELECT latitude, longitude, alert__date, confidence__cat, `
             + `is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest, `
             + `is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> '' THEN 'True' ELSE 'False' END as in_protected_areas `
             + `FROM ${config.get('datasets.viirsDownloadDataset')} `
             + `WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}'`;
-        return `/dataset/${config.get('datasets.viirsDownloadDataset')}/latest/download/{format}?sql=${sql}&geostore_id=${geostoreId}&geostore_origin=rw`;
+        return `/dataset/${config.get('datasets.viirsDownloadDataset')}/latest/download/{format}?sql=${sql}&geostore_id=${geostoreId}&geostore_origin=${geostoreSource}`;
     }
 
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(params);
-        const uri: string = ViirsPresenter.getURLInPeriodForDownload(startDate, endDate, geostoreId);
+        let areaIso: Record<string, any> = {};
+        let area: Record<string, any>;
+        if (params?.area && params?.iso && params.iso?.country) {
+            area = await AreaService.getUserArea(params.area);
+           areaIso = AreaService.getIsoParams(area);
+        }
+
+        const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
+
+        const updatedParams: Record<string, any> = {...params, iso};
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        const uri: string = ViirsPresenter.getURLInPeriodForDownload(startDate, endDate, geostoreId, geostoreSource);
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),
@@ -185,7 +209,7 @@ class ViirsPresenter extends PresenterInterface<ViirsActiveFiresAlertResultType,
             resultObject.week_of = `${startDate.format('DD MMM')}`;
             resultObject.week_start = startDate.format('DD/MM/YYYY');
             resultObject.week_end = endDate.format('DD/MM/YYYY');
-            const alertCount: number = results.data.reduce((acc: number, curr: ViirsActiveFiresAlertResultType) => acc + curr.alert__count, 0)
+            const alertCount: number = results.data.reduce((acc: number, curr: ViirsActiveFiresAlertResultType) => acc + curr.alert__count, 0);
             resultObject.viirs_count = alertCount;
             resultObject.alert_count = alertCount;
 

--- a/src/services/areaService.ts
+++ b/src/services/areaService.ts
@@ -1,0 +1,17 @@
+import { RWAPIMicroservice } from 'rw-api-microservice-node';
+import config from "config";
+
+class AreaService {
+
+    static async getUserArea(areaId: Number): Promise<Record<string, any>> {
+        const body: Record<string, any> = await RWAPIMicroservice.requestToMicroservice({
+            uri: `/v2/area/${areaId}`,
+            params: { 'source[provider]': 'gadm', 'source[version]': config.get('dataApi.gadmVersion') },
+            method: 'GET'
+        });
+ 
+        return body.data;
+    }
+}
+
+export default AreaService;

--- a/src/services/areaService.ts
+++ b/src/services/areaService.ts
@@ -3,15 +3,46 @@ import config from "config";
 
 class AreaService {
 
-    static async getUserArea(areaId: number): Promise<Record<string, any>> {
+    static async getUserArea(areaId: string): Promise<Record<string, any>> {
         const body: Record<string, any> = await RWAPIMicroservice.requestToMicroservice({
             uri: `/v2/area/${areaId}`,
             params: { 'source[provider]': 'gadm', 'source[version]': config.get('dataApi.gadmVersion') },
             method: 'GET'
         });
- 
-        return body.data;
+
+        return body.data.attributes;
+    }
+
+    static getIsoParams(area: Record<string, any>): Record<string, any> {
+        let iso: Record<string, any> = {};
+        if (area?.iso && Object.keys(area.iso).length) {
+            iso = {
+                country: area.iso?.country,
+                region: area.iso?.region,
+                subregion: area.iso?.subregion,
+                source: area.iso?.source
+            };
+        }
+
+        if (area?.admin && Object.keys(area.admin).length) {
+            iso = {
+                country: area.admin?.adm0,
+                region: area.admin?.adm1,
+                subregion: area.admin?.adm2,
+                source: area.admin?.source
+            };
+        }
+    
+        return iso;
+    }
+
+    static getGeostoreSource(area: Record<string, any>): 'gfw' | 'rw' {
+        const iso: Record<string, any> = this.getIsoParams(area);
+        const geostoreSource: 'rw' | 'gfw' = (iso?.source && iso.source?.provider === 'gadm' && iso.source?.version === '4.1') ? 'gfw' : 'rw';
+
+        return geostoreSource;
     }
 }
+
 
 export default AreaService;

--- a/src/services/areaService.ts
+++ b/src/services/areaService.ts
@@ -3,7 +3,7 @@ import config from "config";
 
 class AreaService {
 
-    static async getUserArea(areaId: Number): Promise<Record<string, any>> {
+    static async getUserArea(areaId: number): Promise<Record<string, any>> {
         const body: Record<string, any> = await RWAPIMicroservice.requestToMicroservice({
             uri: `/v2/area/${areaId}`,
             params: { 'source[provider]': 'gadm', 'source[version]': config.get('dataApi.gadmVersion') },

--- a/src/services/geostoreService.ts
+++ b/src/services/geostoreService.ts
@@ -1,4 +1,6 @@
+import axios, { AxiosResponse } from 'axios';
 import logger from 'logger';
+import config from 'config';
 import { RWAPIMicroservice } from 'rw-api-microservice-node';
 
 class GeostoreService {
@@ -37,30 +39,23 @@ class GeostoreService {
     }
 
     static async getGeostoreFromISOCountryCode(countryCode: string): Promise<string> {
-        const uri: string = `/v2/geostore/admin/${countryCode}`;
-        const response: Record<string, any> = await RWAPIMicroservice.requestToMicroservice({
-            uri,
-            method: 'GET',
-        });
-        return response.data.id;
+
+        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}?adminVersion=${config.get('dataApi.gadmVersion')}`;
+        const response: AxiosResponse<Record<string, any>> = await axios.get(uri);
+        return response.data.data.id;
     }
 
     static async getGeostoreFromISORegionCode(countryCode: string, regionCode: string): Promise<string> {
-        const uri: string = `/v2/geostore/admin/${countryCode}/${regionCode}`;
-        const response: Record<string, any> = await RWAPIMicroservice.requestToMicroservice({
-            uri,
-            method: 'GET',
-        });
-        return response.data.id;
+        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}/${regionCode}?adminVersion=${config.get('dataApi.gadmVersion')}`;
+        const response: AxiosResponse<Record<string, any>> = await axios.get(uri);
+        return response.data.data.id;
+
     }
 
     static async getGeostoreFromISOSubregionCode(countryCode: string, regionCode: string, subregionCode: string): Promise<string> {
-        const uri: string = `/v2/geostore/admin/${countryCode}/${regionCode}/${subregionCode}`;
-        const response: Record<string, any> = await RWAPIMicroservice.requestToMicroservice({
-            uri,
-            method: 'GET',
-        });
-        return response.data.id;
+        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}/${regionCode}/${subregionCode}?adminVersion=${config.get('dataApi.gadmVersion')}`;
+        const response: AxiosResponse<Record<string, any>> = await axios.get(uri);
+        return response.data.data.id;
     }
 
     static async getGeostoreFromWDPAID(wdpaId: string): Promise<string> {

--- a/src/services/geostoreService.ts
+++ b/src/services/geostoreService.ts
@@ -40,22 +40,19 @@ class GeostoreService {
 
     static async getGeostoreFromISOCountryCode(countryCode: string): Promise<string> {
 
-        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}?adminVersion=${config.get('dataApi.gadmVersion')}`;
-        const response: AxiosResponse<Record<string, any>> = await axios.get(uri);
-        return response.data.data.id;
+        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}`;
+        return this.getIsoGeostoreId(uri);
     }
 
     static async getGeostoreFromISORegionCode(countryCode: string, regionCode: string): Promise<string> {
-        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}/${regionCode}?adminVersion=${config.get('dataApi.gadmVersion')}`;
-        const response: AxiosResponse<Record<string, any>> = await axios.get(uri);
-        return response.data.data.id;
+        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}/${regionCode}`;
+        return this.getIsoGeostoreId(uri);
 
     }
 
     static async getGeostoreFromISOSubregionCode(countryCode: string, regionCode: string, subregionCode: string): Promise<string> {
-        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}/${regionCode}/${subregionCode}?adminVersion=${config.get('dataApi.gadmVersion')}`;
-        const response: AxiosResponse<Record<string, any>> = await axios.get(uri);
-        return response.data.data.id;
+        const uri: string = `${config.get('dataApi.url')}/geostore/admin/${countryCode}/${regionCode}/${subregionCode}`;
+        return this.getIsoGeostoreId(uri);
     }
 
     static async getGeostoreFromWDPAID(wdpaId: string): Promise<string> {
@@ -74,6 +71,14 @@ class GeostoreService {
             method: 'GET',
         });
         return response.data.id;
+    }
+
+    static async getIsoGeostoreId(uri: string): Promise<string> {
+        const params: Record<string, any> = { adminVersion: config.get('dataApi.gadmVersion') };
+        const response: AxiosResponse<Record<string, any>> = await axios.get(
+            uri, { params }
+        );
+        return response.data.data.id;
     }
 
 }

--- a/subscription.sh
+++ b/subscription.sh
@@ -5,8 +5,8 @@ case "$1" in
         yarn start
         ;;
     develop)
-        type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
-        docker-compose -f docker-compose-develop.yml build && docker-compose -f docker-compose-develop.yml up
+        type docker compose >/dev/null 2>&1 || { echo >&2 "docker compose is required but it's not installed.  Aborting."; exit 1; }
+        docker compose -f docker-compose-develop.yml build && docker compose -f docker-compose-develop.yml up --abort-on-container-exit
         ;;
     test)
         type docker compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }

--- a/subscription.sh
+++ b/subscription.sh
@@ -9,8 +9,8 @@ case "$1" in
         docker-compose -f docker-compose-develop.yml build && docker-compose -f docker-compose-develop.yml up
         ;;
     test)
-        type docker-compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
-        docker-compose -f docker-compose-test.yml build && docker-compose -f docker-compose-test.yml up --abort-on-container-exit
+        type docker compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
+        docker compose -f docker-compose-test.yml build && docker compose -f docker-compose-test.yml up --abort-on-container-exit
         ;;
     *)
         echo "Usage: subscription.sh {start|develop|test}" >&2

--- a/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
@@ -7,8 +7,8 @@ import Subscription, { ISubscription } from 'models/subscription';
 import Statistic from 'models/statistic';
 import AlertQueue from 'queues/alert.queue';
 
-import { createSubscription, createSubscriptionContent } from '../utils/helpers';
-import { createMockGeostore } from '../utils/mock';
+import { createSubscription, createSubscriptionContent, getUUID } from '../utils/helpers';
+import { createMockArea, createMockGeostore } from '../utils/mock';
 import { USERS } from '../utils/test.constants';
 import { getTestServer } from '../utils/test-server';
 import {
@@ -51,13 +51,17 @@ describe('GLAD-ALL alerts', () => {
     });
 
     it('GLAD-ALL alerts matches "glad-all" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const areaId = getUUID()
         const sub: ISubscription = await createSubscription(
             USERS.USER.id,
-            { datasets: ['glad-all'], params: { iso: { country: 'BRA' } } }
+            { datasets: ['glad-all'], params: { iso: { country }, area: areaId } }
         );
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA');
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        logger.info(`sending areaId to mock ${areaId} for ${country}`)
+        createMockArea(areaId, { country }, 2)
 
         mockGLADAllISOQuery();
 
@@ -95,14 +99,18 @@ describe('GLAD-ALL alerts', () => {
     });
 
     it('GLAD-ALL alerts matches "glad-all" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-all',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1');
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region }, 2)
 
         mockGLADAllAdm1Query();
 
@@ -140,15 +148,19 @@ describe('GLAD-ALL alerts', () => {
     });
 
     it('GLAD-ALL alerts matches "glad-all" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const subregion = '2'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-all',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1/2');
-
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion }, 2)
         mockGLADAllAdm2Query();
 
         redisClient.subscribe(CHANNEL, (message) => {

--- a/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
@@ -60,7 +60,6 @@ describe('GLAD-ALL alerts', () => {
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
-        logger.info(`sending areaId to mock ${areaId} for ${country}`)
         createMockArea(areaId, { country }, 2)
 
         mockGLADAllISOQuery();

--- a/test/e2e/email-notifications/glad-alerts-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-emails.spec.ts
@@ -206,7 +206,7 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country })
+        createMockArea(areaId, { country }, 2)
         mockGLADLISOQuery();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -257,7 +257,7 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country, region })
+        createMockArea(areaId, { country, region }, 2)
 
         mockGLADLAdm1Query();
 
@@ -310,7 +310,7 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country, region, subregion })
+        createMockArea(areaId, { country, region, subregion }, 2);
 
         mockGLADLAdm2Query();
 

--- a/test/e2e/email-notifications/glad-alerts-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-emails.spec.ts
@@ -9,8 +9,8 @@ import Statistic from 'models/statistic';
 import AlertQueue from 'queues/alert.queue';
 import EmailHelpersService from 'services/emailHelpersService';
 
-import { createSubscriptionContent, assertNoEmailSent } from '../utils/helpers';
-import { createMockGeostore } from '../utils/mock';
+import { createSubscriptionContent, assertNoEmailSent, getUUID } from '../utils/helpers';
+import { createMockArea, createMockGeostore } from '../utils/mock';
 const {
     bootstrapEmailNotificationTests,
     validateCommonNotificationParams,
@@ -24,6 +24,7 @@ import {
     mockGLADLISOQuery,
     mockGLADLWDPAQuery
 } from '../utils/mocks/gladL.mocks';
+import { getTestServer } from '../utils/test-server';
 
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
@@ -47,6 +48,8 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
             throw Error(`Running the test suite with cron enabled is not supported. You can disable cron by setting the LOAD_CRON env variable to false.`);
         }
 
+        await getTestServer();
+        
         redisClient = createClient({ url: config.get('redis.url') });
         await redisClient.connect();
     });
@@ -191,17 +194,19 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
     });
 
     it('GLAD alert emails for admin 0 subscriptions work as expected', async () => {
+        const country = 'BRA'
+        const areaId = getUUID()
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-alerts',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country }, area: areaId} },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA');
-
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country })
         mockGLADLISOQuery();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -239,16 +244,20 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
     });
 
     it('GLAD alert emails for admin 1 subscriptions work as expected', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const areaId = getUUID()
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-alerts',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1');
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region })
 
         mockGLADLAdm1Query();
 
@@ -287,16 +296,21 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
     });
 
     it('GLAD alert emails for admin 2 subscriptions work as expected', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const subregion = '2'
+        const areaId = getUUID()
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-alerts',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1/2');
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion })
 
         mockGLADLAdm2Query();
 
@@ -392,7 +406,7 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 2);
+        createMockGeostore('/v2/geostore/use/gfw_logging/29407', process.env.GATEWAY_URL, 2);
 
         mockGLADLGeostoreQuery()
 

--- a/test/e2e/email-notifications/glad-alerts-l-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-l-emails.spec.ts
@@ -8,8 +8,8 @@ import Statistic from 'models/statistic';
 import AlertQueue from 'queues/alert.queue';
 
 import { getTestServer } from '../utils/test-server';
-import { createSubscriptionContent } from '../utils/helpers';
-import { createMockGeostore } from '../utils/mock';
+import { createSubscriptionContent, getUUID } from '../utils/helpers';
+import { createMockArea, createMockGeostore } from '../utils/mock';
 import { USERS } from '../utils/test.constants';
 import {
     mockGLADLAdm1Query,
@@ -53,15 +53,17 @@ describe('GLAD-L alerts', () => {
     });
 
     it('GLAD-L alerts matches "glad-l" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-l',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA');
-
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country })
         mockGLADLISOQuery();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -98,15 +100,18 @@ describe('GLAD-L alerts', () => {
     });
 
     it('GLAD-L alerts matches "glad-l" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-l',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1');
-
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region })
         mockGLADLAdm1Query();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -143,15 +148,19 @@ describe('GLAD-L alerts', () => {
     });
 
     it('GLAD-L alerts matches "glad-l" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const subregion = '2'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-l',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1/2');
-
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion })
         mockGLADLAdm2Query();
 
         redisClient.subscribe(CHANNEL, (message) => {

--- a/test/e2e/email-notifications/glad-alerts-l-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-l-emails.spec.ts
@@ -63,7 +63,7 @@ describe('GLAD-L alerts', () => {
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country })
+        createMockArea(areaId, { country }, 2)
         mockGLADLISOQuery();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -111,7 +111,7 @@ describe('GLAD-L alerts', () => {
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country, region })
+        createMockArea(areaId, { country, region }, 2)
         mockGLADLAdm1Query();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -160,7 +160,7 @@ describe('GLAD-L alerts', () => {
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country, region, subregion })
+        createMockArea(areaId, { country, region, subregion }, 2)
         mockGLADLAdm2Query();
 
         redisClient.subscribe(CHANNEL, (message) => {

--- a/test/e2e/email-notifications/glad-alerts-radd-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-radd-emails.spec.ts
@@ -8,8 +8,8 @@ import Statistic from 'models/statistic';
 import AlertQueue from 'queues/alert.queue';
 
 import { getTestServer } from '../utils/test-server';
-import { createSubscriptionContent } from '../utils/helpers';
-import { createMockGeostore } from '../utils/mock';
+import { createSubscriptionContent, getUUID } from '../utils/helpers';
+import { createMockArea, createMockGeostore } from '../utils/mock';
 import { USERS } from '../utils/test.constants';
 import { mockGLADAllGeostoreQuery } from '../utils/mocks/gladAll.mocks';
 import {
@@ -53,15 +53,17 @@ describe('GLAD-RADD alerts', () => {
     });
 
     it('GLAD-RADD alerts matches "glad-radd" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-radd',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country }, area: areaId} },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA');
-
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country }, 2)
         mockGLADRADDISOQuery();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -98,15 +100,18 @@ describe('GLAD-RADD alerts', () => {
     });
 
     it('GLAD-RADD alerts matches "glad-radd" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-radd',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1');
-
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region }, 2)
         mockGLADRADDAdm1Query();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -143,14 +148,19 @@ describe('GLAD-RADD alerts', () => {
     });
 
     it('GLAD-RADD alerts matches "glad-radd" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const subregion = '2'
+        const areaId = getUUID()
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-radd',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1/2');
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion }, 2)
 
         mockGLADRADDAdm2Query();
 

--- a/test/e2e/email-notifications/glad-alerts-s2-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-s2-emails.spec.ts
@@ -8,8 +8,8 @@ import Statistic from 'models/statistic';
 import AlertQueue from 'queues/alert.queue';
 
 import { getTestServer } from '../utils/test-server';
-import { createSubscriptionContent } from '../utils/helpers';
-import { createMockGeostore } from '../utils/mock';
+import { createSubscriptionContent, getUUID } from '../utils/helpers';
+import { createMockArea, createMockGeostore } from '../utils/mock';
 import { USERS } from '../utils/test.constants';
 import {
     mockGLADS2Adm1Query,
@@ -53,15 +53,17 @@ describe('GLAD-S2 alerts', () => {
     });
 
     it('GLAD-S2 alerts matches "glad-s2" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA';
+        const areaId = getUUID();
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-s2',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country }, area: areaId} },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA');
-
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country }, 2);
         mockGLADS2ISOQuery();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -98,15 +100,18 @@ describe('GLAD-S2 alerts', () => {
     });
 
     it('GLAD-S2 alerts matches "glad-s2" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const areaId = getUUID();
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-s2',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1');
-
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region }, 2);
         mockGLADS2Adm1Query();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -143,15 +148,19 @@ describe('GLAD-S2 alerts', () => {
     });
 
     it('GLAD-S2 alerts matches "glad-s2" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const subregion = '2';
+        const areaId = getUUID();
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'glad-s2',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1/2');
-
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion }, 2);
         mockGLADS2Adm2Query();
 
         redisClient.subscribe(CHANNEL, (message) => {

--- a/test/e2e/email-notifications/monthly-summary-alerts-emails.spec.ts
+++ b/test/e2e/email-notifications/monthly-summary-alerts-emails.spec.ts
@@ -8,7 +8,7 @@ import Statistic from 'models/statistic';
 import AlertQueue from 'queues/alert.queue';
 import EmailHelpersService from 'services/emailHelpersService';
 import { getTestServer } from '../utils/test-server';
-import { createSubscriptionContent, assertNoEmailSent } from '../utils/helpers';
+import { createSubscriptionContent, assertNoEmailSent, getUUID } from '../utils/helpers';
 const {
     mockVIIRSAlertsISOQuery,
     mockVIIRSAlertsWDPAQuery,
@@ -29,6 +29,7 @@ import {
     mockGLADLGeostoreQuery,
     mockGLADLISOQuery, mockGLADLWDPAQuery
 } from '../utils/mocks/gladL.mocks';
+import { createMockArea } from '../utils/mock';
 
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
@@ -173,17 +174,20 @@ describe('Monthly summary notifications', () => {
     });
 
     it('Monthly summary alert emails for subscriptions that refer to an ISO code work as expected', async () => {
+        const country = 'BRA';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'monthly-summary',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLISOQuery(2);
         mockVIIRSAlertsISOQuery(2);
+        createMockArea(areaId, { country }, 4)
 
         await redisClient.subscribe(CHANNEL, (message: string) => {
             const jsonMessage = JSON.parse(message);
@@ -217,17 +221,21 @@ describe('Monthly summary notifications', () => {
     });
 
     it('Monthly summary alert emails for subscriptions that refer to an ADM 1 region work as expected', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'monthly-summary',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId} },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLAdm1Query(2);
         mockVIIRSAlertsISOQuery(2);
+        createMockArea(areaId, { country, region }, 4);
         await redisClient.subscribe(CHANNEL, (message: string) => {
             const jsonMessage = JSON.parse(message);
 
@@ -260,17 +268,22 @@ describe('Monthly summary notifications', () => {
     });
 
     it('Monthly summary alert emails for subscriptions that refer to an ADM 2 subregion work as expected', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const subregion = '2';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
             'monthly-summary',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLAdm2Query(2);
         mockVIIRSAlertsISOQuery(2);
+        createMockArea(areaId, { country, region, subregion }, 4);
 
         await redisClient.subscribe(CHANNEL, (message: string) => {
             const jsonMessage = JSON.parse(message);
@@ -359,7 +372,7 @@ describe('Monthly summary notifications', () => {
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLGeostoreQuery(2);
         mockVIIRSAlertsGeostoreQuery(2);
-        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 4);
+        createMockGeostore('/v2/geostore/use/gfw_logging/29407', process.env.GATEWAY_URL, 4);
 
         await redisClient.subscribe(CHANNEL, (message: string) => {
             const jsonMessage = JSON.parse(message);

--- a/test/e2e/email-notifications/viirs-fires-alerts-emails.spec.ts
+++ b/test/e2e/email-notifications/viirs-fires-alerts-emails.spec.ts
@@ -10,8 +10,9 @@ import AlertQueue from 'queues/alert.queue';
 import EmailHelpersService from 'services/emailHelpersService';
 
 import { getTestServer } from '../utils/test-server';
-import { assertNoEmailSent, createSubscription } from '../utils/helpers';
+import { assertNoEmailSent, createSubscription, getUUID } from '../utils/helpers';
 import { USERS } from '../utils/test.constants';
+import { createMockArea } from '../utils/mock';
 
 const {
     mockVIIRSAlertsISOQuery,
@@ -223,18 +224,21 @@ describe('VIIRS Fires alert emails', () => {
     });
 
     it('VIIRS Fires emails for subscriptions that refer to an ISO code work as expected', async () => {
+        const country = 'BRA';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await createSubscription(
             USERS.USER.id,
             {
                 datasets: ['viirs-active-fires'],
-                params: { iso: { country: 'BRA' } }
+                params: { iso: { country }, area: areaId }
             }
         );
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA');
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country }, 3);
         mockVIIRSAlertsISOQuery(2);
 
         let expectedQueueMessageCount = 1;
@@ -288,18 +292,22 @@ describe('VIIRS Fires alert emails', () => {
     });
 
     it('VIIRS Fires emails for subscriptions that refer to an ADM 1 region work as expected', async () => {
+        const country = 'BRA';
+        const region = '3';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await createSubscription(
             USERS.USER.id,
             {
                 datasets: ['viirs-active-fires'],
-                params: { iso: { country: 'BRA', region: '3' } }
+                params: { iso: { country, region }, area: areaId }
             }
         );
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/3');
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region }, 3);
         mockVIIRSAlertsISOQuery(2);
 
         let expectedQueueMessageCount = 1;
@@ -353,18 +361,23 @@ describe('VIIRS Fires alert emails', () => {
     });
 
     it('VIIRS Fires emails for subscriptions that refer to an ADM 2 subregion work as expected', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const subregion = '1';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await createSubscription(
             USERS.USER.id,
             {
                 datasets: ['viirs-active-fires'],
-                params: { iso: { country: 'BRA', region: '1', subregion: '1' } }
+                params: { iso: { country, region, subregion }, area: areaId },
             }
         );
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
-        createMockGeostore('/v2/geostore/admin/BRA/1/1');
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion }, 3);
         mockVIIRSAlertsISOQuery(2);
 
         let expectedQueueMessageCount = 1;
@@ -495,7 +508,7 @@ describe('VIIRS Fires alert emails', () => {
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockVIIRSAlertsGeostoreQuery(2);
-        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 3);
+        createMockGeostore('/v2/geostore/use/gfw_logging/29407', process.env.GATEWAY_URL, 3);
 
         let expectedQueueMessageCount = 1;
 

--- a/test/e2e/url-notifications/glad-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/glad-alerts-urls.spec.ts
@@ -134,7 +134,7 @@ describe('GLAD alert - URL Subscriptions', () => {
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'glad-alerts',
-            { params: { iso: { country: 'BRA' }, area: areaId } },
+            { params: { iso: { country }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();

--- a/test/e2e/url-notifications/glad-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/glad-alerts-urls.spec.ts
@@ -9,7 +9,7 @@ import Statistic from  'models/statistic';
 import AlertQueue from  'queues/alert.queue';
 
 import { getTestServer } from  '../utils/test-server';
-import { createURLSubscription, createURLSubscriptionCallMock } from  '../utils/helpers';
+import { createURLSubscription, createURLSubscriptionCallMock, getUUID } from  '../utils/helpers';
 import { USERS } from  '../utils/test.constants';
 
 import {
@@ -27,7 +27,7 @@ import {
     mockGLADLGeostoreQuery,
     mockGLADLISOQuery, mockGLADLWDPAQuery
 } from '../utils/mocks/gladL.mocks';
-import { createMockGeostore } from '../utils/mock';
+import { createMockArea, createMockGeostore } from '../utils/mock';
 
 nock.disableNetConnect();
 nock.enableNetConnect(process.env.HOST_IP);
@@ -129,16 +129,18 @@ describe('GLAD alert - URL Subscriptions', () => {
     });
 
     it('Updating GLAD alerts dataset triggers the configured subscription url being called using the correct body data - ISO code for country', async () => {
+        const country = 'BRA'
+        const areaId = getUUID()
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'glad-alerts',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country: 'BRA' }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockGLADLISOQuery();
-        createMockGeostore('/v2/geostore/admin/BRA');
-
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country })
         createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA',
         }));
@@ -166,15 +168,19 @@ describe('GLAD alert - URL Subscriptions', () => {
     });
 
     it('Updating GLAD alerts dataset triggers the configured subscription url being called using the correct body data - ISO code for country and region', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const areaId = getUUID()
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'glad-alerts',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockGLADLAdm1Query();
-        createMockGeostore('/v2/geostore/admin/BRA/1');
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region })
 
         createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 1',
@@ -203,15 +209,20 @@ describe('GLAD alert - URL Subscriptions', () => {
     });
 
     it('Updating GLAD alerts dataset triggers the configured subscription url being called using the correct body data - ISO code for country, region and subregion', async () => {
+        const country = 'BRA'
+        const region = '1'
+        const subregion = '2'
+        const areaId = getUUID()
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'glad-alerts',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockGLADLAdm2Query();
-        createMockGeostore('/v2/geostore/admin/BRA/1/2');
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion })
 
         createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2',
@@ -283,7 +294,7 @@ describe('GLAD alert - URL Subscriptions', () => {
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockGLADLGeostoreQuery();
-        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 2);
+        createMockGeostore('/v2/geostore/use/gfw_logging/29407', process.env.GATEWAY_URL, 2);
 
         createURLSubscriptionCallMock(createGLADAlertsGeostoreURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             downloadUrls: {

--- a/test/e2e/url-notifications/glad-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/glad-alerts-urls.spec.ts
@@ -140,7 +140,7 @@ describe('GLAD alert - URL Subscriptions', () => {
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockGLADLISOQuery();
         createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country })
+        createMockArea(areaId, { country }, 2);
         createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA',
         }));
@@ -180,7 +180,7 @@ describe('GLAD alert - URL Subscriptions', () => {
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockGLADLAdm1Query();
         createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country, region })
+        createMockArea(areaId, { country, region }, 2);
 
         createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 1',
@@ -222,7 +222,7 @@ describe('GLAD alert - URL Subscriptions', () => {
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockGLADLAdm2Query();
         createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
-        createMockArea(areaId, { country, region, subregion })
+        createMockArea(areaId, { country, region, subregion }, 2);
 
         createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2',

--- a/test/e2e/url-notifications/monthly-summary-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/monthly-summary-alerts-urls.spec.ts
@@ -9,8 +9,9 @@ import Statistic from 'models/statistic';
 import AlertQueue from 'queues/alert.queue';
 
 import { getTestServer } from '../utils/test-server';
-import { createURLSubscription, createURLSubscriptionCallMock } from '../utils/helpers';
+import { createURLSubscription, createURLSubscriptionCallMock, getUUID } from '../utils/helpers';
 import {
+    createMockArea,
     createMockGeostore,
     mockVIIRSAlertsGeostoreQuery, mockVIIRSAlertsISOQuery,
     mockVIIRSAlertsWDPAQuery
@@ -140,17 +141,20 @@ describe('Monthly summary notifications - URL Subscriptions', () => {
     });
 
     it('Monthly summary alert for url subscriptions that refer to an ISO code work as expected', async () => {
+        const country = 'BRA';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'monthly-summary',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLISOQuery(2);
         mockVIIRSAlertsISOQuery(2);
+        createMockArea(areaId, { country }, 4);
 
         createURLSubscriptionCallMock(createMonthlySummaryISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA',
@@ -181,17 +185,21 @@ describe('Monthly summary notifications - URL Subscriptions', () => {
     });
 
     it('Monthly summary alert for url subscriptions that refer to an ADM 1 region work as expected', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'monthly-summary',
-            { params: { iso: { country: 'BRA', region: '1' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLAdm1Query(2);
         mockVIIRSAlertsISOQuery(2);
+        createMockArea(areaId, { country, region }, 4);
 
         createURLSubscriptionCallMock(createMonthlySummaryISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 1',
@@ -222,17 +230,22 @@ describe('Monthly summary notifications - URL Subscriptions', () => {
     });
 
     it('Monthly summary alert for url subscriptions that refer to an ADM 2 subregion work as expected', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const subregion = '2';
+        const areaId = getUUID()
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'monthly-summary',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '2' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLAdm2Query(2);
         mockVIIRSAlertsISOQuery(2);
+        createMockArea(areaId, { country, region, subregion }, 4);
 
         createURLSubscriptionCallMock(createMonthlySummaryISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2',
@@ -315,7 +328,7 @@ describe('Monthly summary notifications - URL Subscriptions', () => {
         const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
         mockGLADLGeostoreQuery(2);
         mockVIIRSAlertsGeostoreQuery(2);
-        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 4);
+        createMockGeostore('/v2/geostore/use/gfw_logging/29407', process.env.GATEWAY_URL, 4);
 
         createURLSubscriptionCallMock(createMonthlySummaryGeostoreURLSubscriptionBody(subscriptionOne, beginDate, endDate));
 

--- a/test/e2e/url-notifications/viirs-fires-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/viirs-fires-alerts-urls.spec.ts
@@ -10,9 +10,9 @@ import AlertQueue from  'queues/alert.queue';
 import EmailHelpersService from 'services/emailHelpersService';
 
 import { getTestServer } from  '../utils/test-server';
-import { createURLSubscription, createURLSubscriptionCallMock } from  '../utils/helpers';
+import { createURLSubscription, createURLSubscriptionCallMock, getUUID } from  '../utils/helpers';
 import {
-    mockVIIRSAlertsGeostoreQuery, createMockGeostore, mockVIIRSAlertsISOQuery, mockVIIRSAlertsWDPAQuery
+    createMockArea, mockVIIRSAlertsGeostoreQuery, createMockGeostore, mockVIIRSAlertsISOQuery, mockVIIRSAlertsWDPAQuery
 } from '../utils/mock';
 import { USERS } from  '../utils/test.constants';
 
@@ -130,17 +130,20 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
     });
 
     it('VIIRS Fires emails for subscriptions that refer to an ISO code work as expected', async () => {
+        const country = 'BRA';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'viirs-active-fires',
-            { params: { iso: { country: 'BRA' } } },
+            { params: { iso: { country }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockVIIRSAlertsISOQuery(2, config.get('datasets.viirsISODataset'));
-        createMockGeostore('/v2/geostore/admin/BRA');
+        createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country }, 3);
 
         createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA',
@@ -171,17 +174,22 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
     });
 
     it('VIIRS Fires emails for subscriptions that refer to an ISO region work as expected', async () => {
+        const country = 'BRA';
+        const region = '3';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
+
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'viirs-active-fires',
-            { params: { iso: { country: 'BRA', region: '3' } } },
+            { params: { iso: { country, region }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockVIIRSAlertsISOQuery(2, config.get('datasets.viirsISODataset'));
-        createMockGeostore('/v2/geostore/admin/BRA/3');
+        createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region }, 3);
 
         createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 3',
@@ -212,18 +220,22 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
     });
 
     it('VIIRS Fires emails for subscriptions that refer to an ISO subregion work as expected', async () => {
+        const country = 'BRA';
+        const region = '1';
+        const subregion = '1';
+        const areaId = getUUID();
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
         const subscriptionOne = await new Subscription(createURLSubscription(
             USERS.USER.id,
             'viirs-active-fires',
-            { params: { iso: { country: 'BRA', region: '1', subregion: '1' } } },
+            { params: { iso: { country, region, subregion }, area: areaId } },
         )).save();
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockVIIRSAlertsISOQuery(2, config.get('datasets.viirsISODataset'));
-        createMockGeostore('/v2/geostore/admin/BRA/1/1');
-
+        createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
+        createMockArea(areaId, { country, region, subregion }, 3);
         createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             selected_area: 'ISO Code: BRA, ID1: 1, ID2: 1',
         }));
@@ -303,7 +315,7 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
 
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         mockVIIRSAlertsGeostoreQuery(2);
-        createMockGeostore('/v2/geostore/use/gfw_logging/29407', 3);
+        createMockGeostore('/v2/geostore/use/gfw_logging/29407', process.env.GATEWAY_URL, 3);
 
         createURLSubscriptionCallMock(createViirsFireAlertsGeostoreURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
             downloadUrls: {

--- a/test/e2e/utils/mock.ts
+++ b/test/e2e/utils/mock.ts
@@ -422,60 +422,58 @@ export const createMockGeostore = (path: string, apiGateway: string = process.en
     }
 };
 
-export const createMockArea = (areaId: string, iso: Record<string, any>, times: Number = 1) => {
+export const createMockArea = (areaId: string, iso: Record<string, any>, times: number = 1) => {
     nock(process.env.GATEWAY_URL)
         .get(`/v2/area/${areaId}`)
         .query({ 'source[provider]': 'gadm', 'source[version]': '3.6' })
         .times(times)
         .reply(200, {
             data: {
-                "data": {
-                    "type": "area",
-                    "id": areaId,
-                    "attributes": {
-                        name: "Kiambu, Kenya",
-                        application: "gfw",
-                        geostore: "33b01a49bf9b56a8b56ce042a24f6567",
-                        wdpaid: null,
-                        userid: "testuser",
-                        createdAt: "2025-01-29T16:28:54.271Z",
-                        updatedAt: "2025-01-29T16:28:54.271Z",
-                        image: "",
-                        datasets: [],
-                        user: {},
-                        env: "production",
-                        iso: {
-                            country: iso?.country,
-                            region: iso?.region,
-                            subregion: iso?.subregion,
-                            source: {
-                                provider: "gadm",
-                                version: "3.6"
-                            }
-                        },
-                        admin: {
-                            adm0: iso?.country,
-                            adm1: iso?.region,
-                            adm2: iso?.subregion,
-                            source: {
-                                provider: "gadm",
-                                version: "3.6"
-                            }
-                        },
-                        tags: [],
-                        status: "saved",
-                        public: true,
-                        fireAerts: true,
-                        deforestationAlerts: true,
-                        deforestationAlertsType: "glad-all",
-                        webhookUrl: "",
-                        monthlySummary: false,
-                        subscriptionId: "testsub",
-                        email: "test.user@wri.org",
-                        language: "en",
-                        confirmed: false
-                    }
-                }
+                type: "area",
+                id: areaId,
+                attributes: {
+                    name: "Kiambu, Kenya",
+                    application: "gfw",
+                    geostore: "33b01a49bf9b56a8b56ce042a24f6567",
+                    wdpaid: null,
+                    userid: "testuser",
+                    createdAt: "2025-01-29T16:28:54.271Z",
+                    updatedAt: "2025-01-29T16:28:54.271Z",
+                    image: "",
+                    datasets: [],
+                    user: {},
+                    env: "production",
+                    iso: {
+                        country: iso?.country,
+                        region: iso?.region,
+                        subregion: iso?.subregion,
+                        source: {
+                            provider: "gadm",
+                            version: "3.6"
+                        }
+                    },
+                    admin: {
+                        adm0: iso?.country,
+                        adm1: iso?.region,
+                        adm2: iso?.subregion,
+                        source: {
+                            provider: "gadm",
+                            version: "3.6"
+                        }
+                    },
+                    tags: [],
+                    status: "saved",
+                    public: true,
+                    fireAerts: true,
+                    deforestationAlerts: true,
+                    deforestationAlertsType: "glad-all",
+                    webhookUrl: "",
+                    monthlySummary: false,
+                    subscriptionId: "testsub",
+                    email: "test.user@wri.org",
+                    language: "en",
+                    confirmed: false
+            }
             }
         });
 };

--- a/test/e2e/utils/mock.ts
+++ b/test/e2e/utils/mock.ts
@@ -373,38 +373,107 @@ export const mockVIIRSAlertsGeostoreQuery = (
         });
 };
 
-export const createMockGeostore = (path: string, times = 1) => {
-    nock(process.env.GATEWAY_URL)
+export const createMockGeostore = (path: string, apiGateway: string = process.env.GATEWAY_URL, times = 1) => {
+    const geostore = {
+        type: 'geoStore',
+        id: '423e5dfb0448e692f97b590c61f45f22',
+        attributes: {
+            geojson: {
+                features: [{
+                    properties: null,
+                    type: 'Feature',
+                    geometry: {
+                        type: 'MultiPolygon',
+                        coordinates: [[[[117.36772481838, -0.64399409467464]]]]
+                    }
+                }],
+                crs: {},
+                type: 'FeatureCollection'
+            },
+            hash: '423e5dfb0448e692f97b590c61f45f22',
+            provider: {},
+            areaHa: 190132126.08844432,
+            bbox: [95.01091766, -11.00761509, 141.01939392, 5.90682268],
+            lock: false,
+            info: {
+                use: {},
+                iso: 'BRA',
+                name: 'Indonesia',
+                gadm: '3.6',
+                simplifyThresh: 0.1
+            }
+        }
+    }
+    if (apiGateway === process.env.GATEWAY_URL) {
+        nock(apiGateway)
         .get(path)
         .times(times)
         .reply(200, {
+            data: geostore
+        });
+    } else {
+        nock(apiGateway)
+            .get(path)
+            .times(times)
+            .query({ adminVersion: config.get('dataApi.gadmVersion')})
+            .reply(200, {
+                data: geostore
+            });
+    }
+};
+
+export const createMockArea = (areaId: string, iso: Record<string, any>, times: Number = 1) => {
+    nock(process.env.GATEWAY_URL)
+        .get(`/v2/area/${areaId}`)
+        .query({ 'source[provider]': 'gadm', 'source[version]': '3.6' })
+        .times(times)
+        .reply(200, {
             data: {
-                type: 'geoStore',
-                id: '423e5dfb0448e692f97b590c61f45f22',
-                attributes: {
-                    geojson: {
-                        features: [{
-                            properties: null,
-                            type: 'Feature',
-                            geometry: {
-                                type: 'MultiPolygon',
-                                coordinates: [[[[117.36772481838, -0.64399409467464]]]]
+                "data": {
+                    "type": "area",
+                    "id": areaId,
+                    "attributes": {
+                        name: "Kiambu, Kenya",
+                        application: "gfw",
+                        geostore: "33b01a49bf9b56a8b56ce042a24f6567",
+                        wdpaid: null,
+                        userid: "testuser",
+                        createdAt: "2025-01-29T16:28:54.271Z",
+                        updatedAt: "2025-01-29T16:28:54.271Z",
+                        image: "",
+                        datasets: [],
+                        user: {},
+                        env: "production",
+                        iso: {
+                            country: iso?.country,
+                            region: iso?.region,
+                            subregion: iso?.subregion,
+                            source: {
+                                provider: "gadm",
+                                version: "3.6"
                             }
-                        }],
-                        crs: {},
-                        type: 'FeatureCollection'
-                    },
-                    hash: '423e5dfb0448e692f97b590c61f45f22',
-                    provider: {},
-                    areaHa: 190132126.08844432,
-                    bbox: [95.01091766, -11.00761509, 141.01939392, 5.90682268],
-                    lock: false,
-                    info: {
-                        use: {},
-                        iso: 'BRA',
-                        name: 'Indonesia',
-                        gadm: '3.6',
-                        simplifyThresh: 0.1
+                        },
+                        admin: {
+                            adm0: iso?.country,
+                            adm1: iso?.region,
+                            adm2: iso?.subregion,
+                            source: {
+                                provider: "gadm",
+                                version: "3.6"
+                            }
+                        },
+                        tags: [],
+                        status: "saved",
+                        public: true,
+                        fireAerts: true,
+                        deforestationAlerts: true,
+                        deforestationAlertsType: "glad-all",
+                        webhookUrl: "",
+                        monthlySummary: false,
+                        subscriptionId: "testsub",
+                        email: "test.user@wri.org",
+                        language: "en",
+                        confirmed: false
                     }
                 }
             }

--- a/test/unit/services/area-service.spec.ts
+++ b/test/unit/services/area-service.spec.ts
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import nock from 'nock';
+import config from 'config';
+import logger from 'logger';
+import AreaService from 'services/areaService'
+import { createMockArea } from '../../e2e/utils/mock';
+import { getUUID } from '../../e2e/utils/helpers';
+import { ADMIN0_ISO, ADMIN2_ADMIN } from '../utils/test-constants';
+import { getTestServer } from '../../e2e/utils/test-server';
+
+describe('AreaService', () => {
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+        
+        await getTestServer();
+    
+    });
+
+    afterEach(() => {
+        process.removeAllListeners('unhandledRejection');
+
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+    });
+
+    describe('getUserArea', () => {
+        it('should fetch area data and return attributes using nock mock', async () => {
+            const areaId = getUUID();
+            const iso = { country: 'KE', region: 'Kiambu', subregion: 'Thika' };
+
+            createMockArea(areaId, iso);
+
+            const area = await AreaService.getUserArea(areaId);
+
+            logger.info(`area ${area}`)
+
+            expect(area).to.include({
+                name: "Kiambu, Kenya",
+                application: "gfw",
+                userid: "testuser"
+            });
+            expect(area.iso).to.deep.include(iso);
+        });
+    });
+
+    describe('getIsoParams', () => {
+        it('should return ISO parameters when area contains iso data', () => {
+            const result = AreaService.getIsoParams(ADMIN0_ISO);
+            logger.info(`result`)
+            logger.info(`${Object.keys(result)}`)
+            expect(result).to.deep.include(ADMIN0_ISO.iso);
+        });
+
+        it('should return admin-based ISO parameters when area contains admin data', () => {
+            const expected = {
+                country: 'KEN',
+                region: '15',
+                subregion: '1',
+                source: {
+                    provider: 'gadm',
+                    version: '3.6'
+                }};
+            const result = AreaService.getIsoParams(ADMIN2_ADMIN);
+
+            expect(result).to.deep.include(expected);
+        });
+
+        it('should return an empty object when area has no iso or admin data', () => {
+            const result = AreaService.getIsoParams({});
+            expect(result).to.deep.equal({});
+        });
+    });
+
+    describe('getGeostoreSource', () => {
+        it('should return "gfw" when the area has provider gadm and version 4.1', () => {
+            const result = AreaService.getGeostoreSource(ADMIN0_ISO);
+
+            expect(result).to.equal('gfw');
+        });
+
+        it('should return "rw" when the area does not match the gadm provider and version', () => {
+            const result = AreaService.getGeostoreSource(ADMIN2_ADMIN);
+
+            expect(result).to.equal('rw');
+        });
+
+        it('should return "rw" when iso data is missing', () => {
+            const area = {};
+            const result = AreaService.getGeostoreSource(area);
+
+            expect(result).to.equal('rw');
+        });
+    });
+});

--- a/test/unit/services/area-service.spec.ts
+++ b/test/unit/services/area-service.spec.ts
@@ -1,7 +1,5 @@
 import { expect } from 'chai';
 import nock from 'nock';
-import config from 'config';
-import logger from 'logger';
 import AreaService from 'services/areaService'
 import { createMockArea } from '../../e2e/utils/mock';
 import { getUUID } from '../../e2e/utils/helpers';
@@ -35,8 +33,6 @@ describe('AreaService', () => {
 
             const area = await AreaService.getUserArea(areaId);
 
-            logger.info(`area ${area}`)
-
             expect(area).to.include({
                 name: "Kiambu, Kenya",
                 application: "gfw",
@@ -49,16 +45,14 @@ describe('AreaService', () => {
     describe('getIsoParams', () => {
         it('should return ISO parameters when area contains iso data', () => {
             const result = AreaService.getIsoParams(ADMIN0_ISO);
-            logger.info(`result`)
-            logger.info(`${Object.keys(result)}`)
             expect(result).to.deep.include(ADMIN0_ISO.iso);
         });
 
         it('should return admin-based ISO parameters when area contains admin data', () => {
             const expected = {
                 country: 'KEN',
-                region: '15',
-                subregion: '1',
+                region: 15,
+                subregion: 1,
                 source: {
                     provider: 'gadm',
                     version: '3.6'

--- a/test/unit/utils/test-constants.ts
+++ b/test/unit/utils/test-constants.ts
@@ -1,0 +1,65 @@
+const area = {
+    name: "Kiambu, Kenya",
+    application: "gfw",
+    geostore: "33b01a49bf9b56a8b56ce042a24f6567",
+    wdpaid: null,
+    userid: "testuser",
+    createdAt: "2025-01-29T16:28:54.271Z",
+    updatedAt: "2025-01-29T16:28:54.271Z",
+    image: "",
+    datasets: [],
+    user: {},
+    env: "production",
+    tags: [],
+    status: "saved",
+    public: true,
+    fireAerts: true,
+    deforestationAlerts: true,
+    deforestationAlertsType: "glad-all",
+    webhookUrl: "",
+    monthlySummary: false,
+    subscriptionId: "testsub",
+    email: "test.user@wri.org",
+    language: "en",
+    confirmed: false
+}
+
+const admin2Iso = {
+    country: "KEN",
+    region: '15',
+    subregion: '1',
+    source: {
+        provider: "gadm",
+        version: "3.6"
+    }
+}
+
+const admin2Admin = {
+    adm0: "KEN",
+    adm1: '15',
+    adm2: '1',
+    source: {
+        provider: "gadm",
+        version: "3.6"
+    }
+}
+
+const admin1Iso = {
+    country: "KEN",
+    region: '15',
+    source: {
+        provider: "gadm",
+        version: "3.6"
+    }
+}
+
+const admin0Iso = {
+    country: "KEN",
+    source: {
+        provider: "gadm",
+        version: "4.1"
+    }
+}
+
+export const ADMIN2_ADMIN = { ...area, admin: admin2Admin }
+export const ADMIN0_ISO = { ...area, iso: admin0Iso }

--- a/test/unit/utils/test-constants.ts
+++ b/test/unit/utils/test-constants.ts
@@ -24,29 +24,10 @@ const area = {
     confirmed: false
 }
 
-const admin2Iso = {
-    country: "KEN",
-    region: '15',
-    subregion: '1',
-    source: {
-        provider: "gadm",
-        version: "3.6"
-    }
-}
-
 const admin2Admin = {
     adm0: "KEN",
-    adm1: '15',
-    adm2: '1',
-    source: {
-        provider: "gadm",
-        version: "3.6"
-    }
-}
-
-const admin1Iso = {
-    country: "KEN",
-    region: '15',
+    adm1: 15,
+    adm2: 1,
     source: {
         provider: "gadm",
         version: "3.6"


### PR DESCRIPTION
Now that subscription records have the parent area's ID in the `params` object, using this PR's updates we get the area from the area service and use its GADM `iso` or `admin` properties to construct the Data API alerts query for GADM areas. The areas microservice now has the ability to serve areas with GADM versions and this service will rely on that. Moreover, the GADM area's `geostoreId` used to query alert points from the Data API is also now fetched from the Data API instead of RW API as the GADM v4.1 areas are stored in the Data API geostore. For GADM v3.6 which this PR will support, the Data API is proxying the `geostoreId` request to RW API.