### PR TITLE
GTC-3261: Use New Download URL for GADM 4.1 Admin Areas

### DIFF
--- a/config/test.json
+++ b/config/test.json
@@ -1,7 +1,7 @@
 {
   "logger": {
     "name": "gfw-subscription-api-TEST",
-    "level": "debug",
+    "level": "fatal",
     "toFile": false,
     "dirLogFile": null
   },

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -22,8 +22,8 @@ services:
       AWS_ACCESS_KEY_ID: "test"
       AWS_SECRET_ACCESS_KEY: "test"
       REQUIRE_API_KEY: true
-      GADM_VERSION: "3.6"
-    command: test
+      GADM_VERSION: ${GADM_VERSION:-3.6}
+    command: ${TEST_CMD:-test}
     depends_on:
       - mongo
       - redis

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,10 @@ case "$1" in
         echo "Running Test"
         exec yarn test
         ;;
+    test4_1)
+        echo "Running Tests for GADM 4.1"
+        exec yarn test:4_1
+        ;;
     start)
         echo "Running Start"
         exec yarn start

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "app/index.js",
   "scripts": {
     "coverage": "nyc ts-mocha -b --project tsconfig.json -r tsconfig-paths/register --timeout 30000 'test/**/*.ts' --exit",
-    "test": "ts-mocha -b --project tsconfig.json -r tsconfig-paths/register --timeout 30000 'test/**/*.ts' --exit",
+    "test": "ts-mocha -b --project tsconfig.json -r tsconfig-paths/register --timeout 30000 'test/**/*.ts' --exit --grep '@gadm4_1' --invert",
+    "test:4_1": "ts-mocha -b --project tsconfig.json -r tsconfig-paths/register --timeout 30000 'test/**/*.ts' --exit --grep '@gadm4_1'",
     "start": "ts-node --files --project tsconfig.json -r tsconfig-paths/register src/index.ts",
     "run:cron": "ts-node --files --project tsconfig.json -r tsconfig-paths/register src/cronRunner.ts",
     "watch": "ts-node-dev --respawn --transpile-only --files --project tsconfig.json -r tsconfig-paths/register src/index.ts",

--- a/src/app.ts
+++ b/src/app.ts
@@ -63,7 +63,10 @@ const init: () => Promise<IInit> = async (): Promise<IInit> => {
                 // instance of koa
                 const app: Koa = new Koa();
                 app.use(koaSimpleHealthCheck());
-                app.use(koaLogger());
+
+                if (process.env.NODE_ENV !== 'test') {
+                    app.use(koaLogger());
+                }
 
                 koaQs(app, 'extended');
                 app.use(

--- a/src/presenters/gladAllPresenter.ts
+++ b/src/presenters/gladAllPresenter.ts
@@ -72,10 +72,25 @@ class GLADAllPresenter extends PresenterInterface<GladAllAlertResultType, GladAl
     }
 
     static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'rw' | 'gfw' = 'rw'): string {
-        const sql: string = `SELECT latitude, longitude, gfw_integrated_alerts__date, umd_glad_landsat_alerts__confidence, umd_glad_sentinel2_alerts__confidence, `
+        const sql: string = GLADAllPresenter.#buildDownloadSQL(startDate, endDate);
+        return `${DATASET_GLAD_ALL_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
+    }
+
+    static #getAdminURLForDownload(startDate: string, endDate: string, params: Record<string, any>):string {
+        const { country, region, subregion, source: { provider, version } } = params.iso;
+        const sql: string = GLADAllPresenter.#buildDownloadSQL(startDate, endDate);
+        return `${DATASET_GLAD_ALL_DOWNLOAD}_by_aoi/{format}?sql=${sql}` +
+            `&aoi[country]=${country}` +
+            (region ? `&aoi[region]=${region}` : '') +
+            (subregion ? `&aoi[subregion]=${subregion}` : '') +
+            (provider ? `&aoi[provider]=${provider}`: '') +
+            (version? `&aoi[version]=${version}` : '');
+    }
+
+    static #buildDownloadSQL(startDate: string, endDate: string): string {
+        return `SELECT latitude, longitude, gfw_integrated_alerts__date, umd_glad_landsat_alerts__confidence, umd_glad_sentinel2_alerts__confidence, `
             + `wur_radd_alerts__confidence, gfw_integrated_alerts__confidence FROM data WHERE gfw_integrated_alerts__date >= '${startDate}' `
             + `AND gfw_integrated_alerts__date <= '${endDate}'`;
-        return `${DATASET_GLAD_ALL_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
     }
 
     static async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
@@ -131,22 +146,37 @@ class GLADAllPresenter extends PresenterInterface<GladAllAlertResultType, GladAl
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
         let areaIso: Record<string, any> = {};
         let area: Record<string, any>;
+
         if (params?.area && params?.iso && params.iso?.country) {
             area = await AreaService.getUserArea(params.area);
            areaIso = AreaService.getIsoParams(area);
         }
 
         const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
-
         const updatedParams: Record<string, any> = {...params, iso};
-        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
-        const uri: string = GLADAllPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+
+        let uri: string;
+        if (AreaService.areaIsAdminBoundary(area, { provider: 'gadm', version: '4.1' })) {
+            uri = this.buildAdminURL(updatedParams, startDate, endDate);
+        } else {
+            uri = await this.buildGeostoreURL(area, updatedParams, startDate, endDate);
+        }
+
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),
         };
     }
+
+    private async buildGeostoreURL(area: Record<string, any>, updatedParams: Record<string, any>, startDate: string, endDate: string): Promise<string> {
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        return GLADAllPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+    }
+
+    private buildAdminURL(params: Record<string, any>, startDate: string, endDate: string):string {
+        return GLADAllPresenter.#getAdminURLForDownload(startDate, endDate, params);
+    };
 
     buildResultObject(results: AlertResultWithCount<GladAllAlertResultType>, subscription: ISubscription, layer: ILayer, begin: Date, end: Date): GladAllPresenterResponse {
         const resultObject: Partial<GladAllPresenterResponse> = { value: results.value };
@@ -218,7 +248,6 @@ class GLADAllPresenter extends PresenterInterface<GladAllAlertResultType, GladAl
         }
 
     }
-
 }
 
 export default new GLADAllPresenter();

--- a/src/services/areaService.ts
+++ b/src/services/areaService.ts
@@ -9,7 +9,6 @@ class AreaService {
             params: { 'source[provider]': 'gadm', 'source[version]': config.get('dataApi.gadmVersion') },
             method: 'GET'
         });
-
         return body.data.attributes;
     }
 
@@ -37,10 +36,13 @@ class AreaService {
     }
 
     static getGeostoreSource(area: Record<string, any>): 'gfw' | 'rw' {
-        const iso: Record<string, any> = this.getIsoParams(area);
-        const geostoreSource: 'rw' | 'gfw' = (iso?.source && iso.source?.provider === 'gadm' && iso.source?.version === '4.1') ? 'gfw' : 'rw';
+        return AreaService.areaIsAdminBoundary(area, { provider: 'gadm', version: '4.1' }) ? 'gfw' : 'rw';
+    }
 
-        return geostoreSource;
+    static areaIsAdminBoundary(area: Record<string, any>, source: { provider: string; version: string }): boolean {
+        const { provider, version } = source;
+        const iso: Record<string, any> = this.getIsoParams(area);
+        return iso?.source && iso.source?.provider === provider && iso.source?.version === version;
     }
 }
 

--- a/subscription.sh
+++ b/subscription.sh
@@ -10,7 +10,25 @@ case "$1" in
         ;;
     test)
         type docker compose >/dev/null 2>&1 || { echo >&2 "docker-compose is required but it's not installed.  Aborting."; exit 1; }
-        docker compose -f docker-compose-test.yml build && docker compose -f docker-compose-test.yml up --abort-on-container-exit
+        EXIT_CODE=0
+
+        GADM_VERSION=3.6 docker compose -f docker-compose-test.yml build && \
+        GADM_VERSION=3.6 docker compose -f docker-compose-test.yml up --abort-on-container-exit
+        (( EXIT_CODE |= $? ))  # Bitwise OR to capture any failure
+
+        GADM_VERSION=4.1 TEST_CMD=test4_1 docker compose -f docker-compose-test.yml build && \
+        GADM_VERSION=4.1 TEST_CMD=test4_1 docker compose -f docker-compose-test.yml up --abort-on-container-exit
+        (( EXIT_CODE |= $? ))  # Bitwise OR to capture any failure
+
+        if [ $EXIT_CODE -eq 0 ]; then
+            echo ""
+            echo "SUCCESS: All tests passed!"
+        else
+            echo ""
+            echo "ERROR: Some tests failed!" >&2
+        fi
+
+        exit $EXIT_CODE
         ;;
     *)
         echo "Usage: subscription.sh {start|develop|test}" >&2

--- a/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
@@ -304,7 +304,7 @@ describe('GLAD-ALL alerts', () => {
         }));
     });
 
-    xdescribe("GADM 4.1 Administrative Areas", () => {
+    describe("GADM 4.1 Administrative Areas @gadm4_1", () => {
         it('GLAD-ALL alerts matches "glad-all" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
             const country = 'BRA';
             const areaId = getUUID();

--- a/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-all-emails.spec.ts
@@ -72,7 +72,11 @@ describe('GLAD-ALL alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladAll(jsonMessage, sub, beginDate, endDate,
+                    validateGladAll(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -121,7 +125,11 @@ describe('GLAD-ALL alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladAll(jsonMessage, sub, beginDate, endDate,
+                    validateGladAll(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -170,7 +178,11 @@ describe('GLAD-ALL alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladAll(jsonMessage, sub, beginDate, endDate,
+                    validateGladAll(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -215,7 +227,11 @@ describe('GLAD-ALL alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladAll(jsonMessage, sub, beginDate, endDate,
+                    validateGladAll(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -259,7 +275,11 @@ describe('GLAD-ALL alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladAll(jsonMessage, sub, beginDate, endDate,
+                    validateGladAll(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -284,9 +304,169 @@ describe('GLAD-ALL alerts', () => {
         }));
     });
 
+    xdescribe("GADM 4.1 Administrative Areas", () => {
+        it('GLAD-ALL alerts matches "glad-all" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA';
+            const areaId = getUUID();
+            const sub: ISubscription = await createSubscription(
+                USERS.USER.id,
+                { datasets: ['glad-all'], params: { iso: { country, source: { provider: 'gadm', version: '4.1' } }, area: areaId } }
+            );
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            mockGLADAllISOQuery();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladAll(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[country]': 'BRA',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD-ALL alerts matches "glad-all" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const areaId = getUUID();
+            const sub: ISubscription = await createSubscription(
+                USERS.USER.id,
+                { datasets: ['glad-all'], params: { iso: { country, region, source: { provider: 'gadm', version: '4.1' } }, area: areaId } }
+            );
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            mockGLADAllAdm1Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladAll(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD-ALL alerts matches "glad-all" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const subregion = '2';
+            const areaId = getUUID();
+            const sub: ISubscription = await createSubscription(
+                USERS.USER.id,
+                { datasets: ['glad-all'], params: { iso: { country, region, subregion, source: { provider: 'gadm', version: '4.1' } }, area: areaId } }
+            );
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            mockGLADAllAdm2Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladAll(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[subregion]': '2',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+    });
+
     afterEach(async () => {
         await redisClient.unsubscribe(CHANNEL);
-        ;
         process.removeAllListeners('unhandledRejection');
 
         if (!nock.isDone()) {

--- a/test/e2e/utils/helpers/email-notifications.ts
+++ b/test/e2e/utils/helpers/email-notifications.ts
@@ -201,6 +201,8 @@ export const validateGladAll = (
     sub: ISubscription,
     beginDate: Moment,
     endDate: Moment,
+    downloadEndpoint: string,
+    expectedQueryParameters: Record<string, string>,
     {
         total, area, intactForestArea, primaryForestArea, peatArea, wdpaArea, lang = 'en'
     }: {
@@ -214,18 +216,26 @@ export const validateGladAll = (
     jsonMessage.data.downloadUrls.should.have.property('csv')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/gfw_integrated_alerts/latest/download/csv')
+        .and.contain(`/dataset/gfw_integrated_alerts/latest/${downloadEndpoint}/csv`)
         .and.contain('SELECT latitude, longitude, gfw_integrated_alerts__date, umd_glad_landsat_alerts__confidence, umd_glad_sentinel2_alerts__confidence, wur_radd_alerts__confidence, gfw_integrated_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const csvUrl = new URL(jsonMessage.data.downloadUrls['csv']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        csvUrl.searchParams.get(key).should.equal(value);
+    });
 
     jsonMessage.data.downloadUrls.should.have.property('json')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/gfw_integrated_alerts/latest/download/json')
+        .and.contain(`/dataset/gfw_integrated_alerts/latest/${downloadEndpoint}/json`)
         .and.contain('SELECT latitude, longitude, gfw_integrated_alerts__date, umd_glad_landsat_alerts__confidence, umd_glad_sentinel2_alerts__confidence, wur_radd_alerts__confidence, gfw_integrated_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const jsonUrl = new URL(jsonMessage.data.downloadUrls['json']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        jsonUrl.searchParams.get(key).should.equal(value);
+    });
 
     jsonMessage.data.should.have.property('alert_count').and.equal(total);
     jsonMessage.data.should.have.property('value').and.equal(total);

--- a/test/e2e/utils/mock.ts
+++ b/test/e2e/utils/mock.ts
@@ -425,7 +425,7 @@ export const createMockGeostore = (path: string, apiGateway: string = process.en
 export const createMockArea = (areaId: string, iso: Record<string, any>, times: number = 1) => {
     nock(process.env.GATEWAY_URL)
         .get(`/v2/area/${areaId}`)
-        .query({ 'source[provider]': 'gadm', 'source[version]': '3.6' })
+        .query({ 'source[provider]': (iso?.source?.provider ?? 'gadm'), 'source[version]': (iso?.source?.version ?? '3.6') })
         .times(times)
         .reply(200, {
             data: {
@@ -448,8 +448,8 @@ export const createMockArea = (areaId: string, iso: Record<string, any>, times: 
                         region: iso?.region,
                         subregion: iso?.subregion,
                         source: {
-                            provider: "gadm",
-                            version: "3.6"
+                            provider: (iso?.source?.provider ?? "gadm"),
+                            version: (iso?.source?.version?? "3.6")
                         }
                     },
                     admin: {
@@ -457,8 +457,8 @@ export const createMockArea = (areaId: string, iso: Record<string, any>, times: 
                         adm1: iso?.region,
                         adm2: iso?.subregion,
                         source: {
-                            provider: "gadm",
-                            version: "3.6"
+                            provider: (iso?.source?.provider ?? "gadm"),
+                            version: (iso ?.source?.version ?? "3.6")
                         }
                     },
                     tags: [],


### PR DESCRIPTION
**Download URL Generation Methods**

This PR introduces a distinction between two types of download URL generation to properly handle GADM 4.1 admin boundary subscriptions versus geostore-based subscriptions:

1. **Admin Boundary Downloads (`buildAdminURL`)**:
   - Used for subscriptions tied to GADM 4.1 administrative boundaries (countries, regions, subregions)
   - Generates URLs using the `_by_aoi`-flavored endpoint that works with GADM identifiers
   - Constructs the URL by combining:
     - Administrative parameters (country, region, subregion)
     - Optional provider/version information

2. **Geostore Downloads (`buildGeostoreURL`)**:
   - Used for all other subscription types (custom areas, WDPA, GADM 3.6, etc.)
   - Generates URLs using the standard (legacy) download endpoint

**Key Changes in this PR**:
- Added logic to detect GADM 4.1 admin boundaries via `AreaService.areaIsAdminBoundary()`
- Split download URL generation into two distinct paths
- GADM 4.1 Admin boundaries now use their native identifiers rather than being forced into geostore-based downloads
- Maintained backward compatibility for non-admin and GADM 3.6 subscriptions

**Why This Was Needed**:
Data API does not store simplified GADM 4.1 administrative boundaries. The previous implementation that always used geostore-based downloads wouldn't work for these administrative subscriptions. This change ensures:
- More accurate downloads for admin-based subscriptions (starting with GADM 4.1)
- Clear separation between admin and geostore-based data access patterns

The methods work together through `getDownloadURLs()` which routes to the appropriate URL builder based on the subscription type.