### PR TITLE
GTC-3261: New Download URLs for All Presenters

### DIFF
--- a/src/presenters/gladLPresenter.ts
+++ b/src/presenters/gladLPresenter.ts
@@ -72,9 +72,36 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     }
 
     static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
-        const sql: string = `SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence `
-            + `FROM data WHERE umd_glad_landsat_alerts__date >= '${startDate}' AND umd_glad_landsat_alerts__date <= '${endDate}'`;
+        const sql: string = GLADLPresenter.#buildDownloadSQL(startDate, endDate);
         return `${DATASET_GLAD_L_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
+    }
+
+    static #getAdminURLForDownload(startDate: string, endDate: string, params: Record<string, any>):string {
+        const parseSimplifyGeom = (iso: string, id1: string, id2: string): number => {
+            const bigCountries: string[] = ['USA', 'RUS', 'CAN', 'CHN', 'BRA', 'IDN'];
+            const baseThresh: 0.1|0.005 = bigCountries.includes(iso) ? 0.1 : 0.005;
+            if (iso && !id1 && !id2) {
+                return baseThresh;
+            }
+            return id1 && !id2 ? baseThresh / 10 : baseThresh / 100;
+        };
+
+        const { country, region, subregion, source: { provider, version } } = params.iso;
+        const simplify: number = parseSimplifyGeom(country, region, subregion);
+        const sql: string = GLADLPresenter.#buildDownloadSQL(startDate, endDate);
+        return `${DATASET_GLAD_L_DOWNLOAD}_by_aoi/{format}?sql=${sql}` +
+            '&aoi[type]=admin' +
+            `&aoi[country]=${country}` +
+            (region ? `&aoi[region]=${region}` : '') +
+            (subregion ? `&aoi[subregion]=${subregion}` : '') +
+            (provider ? `&aoi[provider]=${provider}`: '') +
+            (version ? `&aoi[version]=${version}` : '') +
+            (simplify ? `&aoi[simplify]=${simplify}` : '');
+    }
+
+    static #buildDownloadSQL(startDate: string, endDate: string): string {
+        return `SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence `
+            + `FROM data WHERE umd_glad_landsat_alerts__date >= '${startDate}' AND umd_glad_landsat_alerts__date <= '${endDate}'`;
     }
 
     async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
@@ -140,22 +167,38 @@ class GLADLPresenter extends PresenterInterface<GladLAlertResultType, GladLPrese
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
         let areaIso: Record<string, any> = {};
         let area: Record<string, any>;
+
         if (params?.area && params?.iso && params.iso?.country) {
             area = await AreaService.getUserArea(params.area);
-           areaIso = AreaService.getIsoParams(area);
+            areaIso = AreaService.getIsoParams(area);
         }
 
         const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
-
         const updatedParams: Record<string, any> = {...params, iso};
-        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
-        const uri: string = GLADLPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+
+        let uri: string;
+        if (AreaService.areaIsAdminBoundary(area, { provider: 'gadm', version: '4.1' })) {
+            uri = this.buildAdminURL(updatedParams, startDate, endDate);
+        } else {
+            uri = await this.buildGeostoreURL(area, updatedParams, startDate, endDate);
+        }
+
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),
         };
     }
+
+    private async buildGeostoreURL(area: Record<string, any>, updatedParams: Record<string, any>, startDate: string, endDate: string): Promise<string> {
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        return GLADLPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+    }
+
+    private buildAdminURL(params: Record<string, any>, startDate: string, endDate: string):string {
+        return GLADLPresenter.#getAdminURLForDownload(startDate, endDate, params);
+    };
+
 
     buildResultObject(results: AlertResultWithCount<GladLAlertResultType>, subscription: ISubscription, layer: ILayer, begin: Date, end: Date): GladLPresenterResponse {
         const resultObject: Partial<GladLPresenterResponse> = { value: results.value };

--- a/src/presenters/gladRaddPresenter.ts
+++ b/src/presenters/gladRaddPresenter.ts
@@ -70,9 +70,36 @@ class GLADRaddPresenter extends PresenterInterface<GladRaddAlertResultType, Glad
     }
 
     static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
-        const sql: string = `SELECT latitude, longitude, wur_radd_alerts__date, wur_radd_alerts__confidence `
-            + `FROM data WHERE wur_radd_alerts__date >= '${startDate}' AND wur_radd_alerts__date <= '${endDate}'`;
+        const sql: string = GLADRaddPresenter.#buildDownloadSQL(startDate, endDate);
         return `${DATASET_GLAD_RADD_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
+    }
+
+    static #getAdminURLForDownload(startDate: string, endDate: string, params: Record<string, any>):string {
+        const parseSimplifyGeom = (iso: string, id1: string, id2: string): number => {
+            const bigCountries: string[] = ['USA', 'RUS', 'CAN', 'CHN', 'BRA', 'IDN'];
+            const baseThresh: 0.1|0.005 = bigCountries.includes(iso) ? 0.1 : 0.005;
+            if (iso && !id1 && !id2) {
+                return baseThresh;
+            }
+            return id1 && !id2 ? baseThresh / 10 : baseThresh / 100;
+        };
+
+        const { country, region, subregion, source: { provider, version } } = params.iso;
+        const simplify: number = parseSimplifyGeom(country, region, subregion);
+        const sql: string = GLADRaddPresenter.#buildDownloadSQL(startDate, endDate);
+        return `${DATASET_GLAD_RADD_DOWNLOAD}_by_aoi/{format}?sql=${sql}` +
+            '&aoi[type]=admin' +
+            `&aoi[country]=${country}` +
+            (region ? `&aoi[region]=${region}` : '') +
+            (subregion ? `&aoi[subregion]=${subregion}` : '') +
+            (provider ? `&aoi[provider]=${provider}`: '') +
+            (version ? `&aoi[version]=${version}` : '') +
+            (simplify ? `&aoi[simplify]=${simplify}` : '');
+    }
+
+    static #buildDownloadSQL(startDate: string, endDate: string): string {
+        return `SELECT latitude, longitude, wur_radd_alerts__date, wur_radd_alerts__confidence `
+            + `FROM data WHERE wur_radd_alerts__date >= '${startDate}' AND wur_radd_alerts__date <= '${endDate}'`;
     }
 
     static async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
@@ -128,21 +155,36 @@ class GLADRaddPresenter extends PresenterInterface<GladRaddAlertResultType, Glad
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
         let areaIso: Record<string, any> = {};
         let area: Record<string, any>;
+
         if (params?.area && params?.iso && params.iso?.country) {
             area = await AreaService.getUserArea(params.area);
            areaIso = AreaService.getIsoParams(area);
         }
 
         const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
-
         const updatedParams: Record<string, any> = {...params, iso};
-        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
-        const uri: string = GLADRaddPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+
+        let uri: string;
+        if (AreaService.areaIsAdminBoundary(area, { provider: 'gadm', version: '4.1' })) {
+            uri = this.buildAdminURL(updatedParams, startDate, endDate);
+        } else {
+            uri = await this.buildGeostoreURL(area, updatedParams, startDate, endDate);
+        }
+
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),
         };
+    }
+
+    private async buildGeostoreURL(area: Record<string, any>, updatedParams: Record<string, any>, startDate: string, endDate: string): Promise<string> {
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        return GLADRaddPresenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+    }
+
+    private buildAdminURL(params: Record<string, any>, startDate: string, endDate: string):string {
+        return GLADRaddPresenter.#getAdminURLForDownload(startDate, endDate, params);
     }
 
     async transform(results: AlertResultWithCount<GladRaddAlertResultType>, subscription: ISubscription, layer: ILayer, begin: Date, end: Date): Promise<GladRaddPresenterResponse> {

--- a/src/presenters/gladS2Presenter.ts
+++ b/src/presenters/gladS2Presenter.ts
@@ -70,9 +70,36 @@ class GLADS2Presenter extends PresenterInterface<GladS2AlertResultType, GladS2Pr
     }
 
     static #getURLForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
-        const sql: string = `SELECT latitude, longitude, umd_glad_sentinel2_alerts__date, umd_glad_sentinel2_alerts__confidence `
-            + `FROM data WHERE umd_glad_sentinel2_alerts__date >= ${startDate} AND umd_glad_sentinel2_alerts__date <= ${endDate}`;
+        const sql: string = GLADS2Presenter.#buildDownloadSQL(startDate, endDate);
         return `${DATASET_GLAD_S2_DOWNLOAD}/{format}?sql=${sql}&geostore_origin=${geostoreSource}&geostore_id=${geostoreId}`;
+    }
+
+    static #getAdminURLForDownload(startDate: string, endDate: string, params: Record<string, any>):string {
+        const parseSimplifyGeom = (iso: string, id1: string, id2: string): number => {
+            const bigCountries: string[] = ['USA', 'RUS', 'CAN', 'CHN', 'BRA', 'IDN'];
+            const baseThresh: 0.1|0.005 = bigCountries.includes(iso) ? 0.1 : 0.005;
+            if (iso && !id1 && !id2) {
+                return baseThresh;
+            }
+            return id1 && !id2 ? baseThresh / 10 : baseThresh / 100;
+        };
+
+        const { country, region, subregion, source: { provider, version } } = params.iso;
+        const simplify: number = parseSimplifyGeom(country, region, subregion);
+        const sql: string = GLADS2Presenter.#buildDownloadSQL(startDate, endDate);
+        return `${DATASET_GLAD_S2_DOWNLOAD}_by_aoi/{format}?sql=${sql}` +
+            '&aoi[type]=admin' +
+            `&aoi[country]=${country}` +
+            (region ? `&aoi[region]=${region}` : '') +
+            (subregion ? `&aoi[subregion]=${subregion}` : '') +
+            (provider ? `&aoi[provider]=${provider}`: '') +
+            (version ? `&aoi[version]=${version}` : '') +
+            (simplify ? `&aoi[simplify]=${simplify}` : '');
+    }
+
+    static #buildDownloadSQL(startDate: string, endDate: string): string {
+        return `SELECT latitude, longitude, umd_glad_sentinel2_alerts__date, umd_glad_sentinel2_alerts__confidence `
+            + `FROM data WHERE umd_glad_sentinel2_alerts__date >= ${startDate} AND umd_glad_sentinel2_alerts__date <= ${endDate}`;
     }
 
     static async getURLForSubscription(startDate: string, endDate: string, params: Record<string, any>): Promise<string> {
@@ -128,21 +155,36 @@ class GLADS2Presenter extends PresenterInterface<GladS2AlertResultType, GladS2Pr
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
         let areaIso: Record<string, any> = {};
         let area: Record<string, any>;
+
         if (params?.area && params?.iso && params.iso?.country) {
             area = await AreaService.getUserArea(params.area);
            areaIso = AreaService.getIsoParams(area);
         }
 
         const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
-
         const updatedParams: Record<string, any> = {...params, iso};
-        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
-        const uri: string = GLADS2Presenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+
+        let uri: string;
+        if (AreaService.areaIsAdminBoundary(area, { provider: 'gadm', version: '4.1' })) {
+            uri = this.buildAdminURL(updatedParams, startDate, endDate);
+        } else {
+            uri = await this.buildGeostoreURL(area, updatedParams, startDate, endDate);
+        }
+
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),
         };
+    }
+
+    private async buildGeostoreURL(area: Record<string, any>, updatedParams: Record<string, any>, startDate: string, endDate: string): Promise<string> {
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        return GLADS2Presenter.#getURLForDownload(startDate, endDate, geostoreId, geostoreSource);
+    }
+
+    private buildAdminURL(params: Record<string, any>, startDate: string, endDate: string):string {
+        return GLADS2Presenter.#getAdminURLForDownload(startDate, endDate, params);
     }
 
     async transform(results: AlertResultWithCount<GladS2AlertResultType>, subscription: ISubscription, layer: ILayer, begin: Date, end: Date): Promise<GladS2PresenterResponse> {

--- a/src/presenters/presenter.interface.ts
+++ b/src/presenters/presenter.interface.ts
@@ -29,7 +29,7 @@ export type PriorityArea = {
     other: number
 };
 
-export type AlertResultWithCount<T extends AlertResultType> = { value: number, data: T[] }
+export type AlertResultWithCount<T extends AlertResultType> = { value: number, data: T[] };
 
 const ALERT_TYPES: string[] = ['EMAIL', 'URL'];
 
@@ -110,9 +110,9 @@ export abstract class PresenterInterface<T extends AlertResultType, U extends Pr
         }
     }
 
-    protected abstract getAlertsForSubscription(startDate: string, endDate: string, params: Record<string, any>, layerSlug: string): Promise<T[]>
+    protected abstract getAlertsForSubscription(startDate: string, endDate: string, params: Record<string, any>, layerSlug: string): Promise<T[]>;
 
-    protected abstract transform(results: AlertResultWithCount<T>, subscription: ISubscription, layer: ILayer, begin: Date, end: Date): Promise<U>
+    protected abstract transform(results: AlertResultWithCount<T>, subscription: ISubscription, layer: ILayer, begin: Date, end: Date): Promise<U>;
 
     protected async getAlertsWithCountForSubscription(startDate: string, endDate: string, params: Record<string, any>, layerSlug: string): Promise<AlertResultWithCount<T>> {
         const analysisResults: T[] = await this.getAlertsForSubscription(startDate, endDate, params, layerSlug);
@@ -158,7 +158,7 @@ export abstract class PresenterInterface<T extends AlertResultType, U extends Pr
 
         if (publish) {
             logger.debug('[PresenterInterface] Saving statistic and notifying user');
-            await this.notifyUser(analysisResultsWithCount, subscription, layer, begin, end)
+            await this.notifyUser(analysisResultsWithCount, subscription, layer, begin, end);
             await new Statistic({ slug: layerConfig.slug, application: subscription.application }).save();
         }
 

--- a/src/presenters/viirsPresenter.ts
+++ b/src/presenters/viirsPresenter.ts
@@ -87,6 +87,42 @@ class ViirsPresenter extends PresenterInterface<ViirsActiveFiresAlertResultType,
         return `/dataset/${config.get('datasets.viirsGeostoreDataset')}/latest/query?sql=${sql}`;
     }
 
+    static getURLInPeriodForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
+        const sql: string = ViirsPresenter.#buildDownloadSQL(startDate, endDate);
+        return `/dataset/${config.get('datasets.viirsDownloadDataset')}/latest/download/{format}?sql=${sql}&geostore_id=${geostoreId}&geostore_origin=${geostoreSource}`;
+    }
+
+    static #getAdminURLForDownload(startDate: string, endDate: string, params: Record<string, any>):string {
+        const parseSimplifyGeom = (iso: string, id1: string, id2: string): number => {
+            const bigCountries: string[] = ['USA', 'RUS', 'CAN', 'CHN', 'BRA', 'IDN'];
+            const baseThresh: 0.1|0.005 = bigCountries.includes(iso) ? 0.1 : 0.005;
+            if (iso && !id1 && !id2) {
+                return baseThresh;
+            }
+            return id1 && !id2 ? baseThresh / 10 : baseThresh / 100;
+        };
+
+        const { country, region, subregion, source: { provider, version } } = params.iso;
+        const simplify: number = parseSimplifyGeom(country, region, subregion);
+        const sql: string = ViirsPresenter.#buildDownloadSQL(startDate, endDate);
+        return `/dataset/${config.get('datasets.viirsDownloadDataset')}/latest/download_by_aoi/{format}?sql=${sql}` +
+            '&aoi[type]=admin' +
+            `&aoi[country]=${country}` +
+            (region ? `&aoi[region]=${region}` : '') +
+            (subregion ? `&aoi[subregion]=${subregion}` : '') +
+            (provider ? `&aoi[provider]=${provider}`: '') +
+            (version ? `&aoi[version]=${version}` : '') +
+            (simplify ? `&aoi[simplify]=${simplify}` : '');
+    }
+
+    static #buildDownloadSQL(startDate: string, endDate: string): string {
+        return `SELECT latitude, longitude, alert__date, confidence__cat, `
+            + `is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest, `
+            + `is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> '' THEN 'True' ELSE 'False' END as in_protected_areas `
+            + `FROM ${config.get('datasets.viirsDownloadDataset')} `
+            + `WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}'`;
+    }
+
     /**
      * Returns the URL for the query for VIIRS alerts for the provided period (startDate to endDate). The params are
      * taken into account to decide which dataset will be used to fetch the alerts.
@@ -165,15 +201,6 @@ class ViirsPresenter extends PresenterInterface<ViirsActiveFiresAlertResultType,
         );
     }
 
-    static getURLInPeriodForDownload(startDate: string, endDate: string, geostoreId: string, geostoreSource: 'gfw' | 'rw' = 'rw'): string {
-        const sql: string = `SELECT latitude, longitude, alert__date, confidence__cat, `
-            + `is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest, `
-            + `is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> '' THEN 'True' ELSE 'False' END as in_protected_areas `
-            + `FROM ${config.get('datasets.viirsDownloadDataset')} `
-            + `WHERE alert__date > '${startDate}' AND alert__date <= '${endDate}'`;
-        return `/dataset/${config.get('datasets.viirsDownloadDataset')}/latest/download/{format}?sql=${sql}&geostore_id=${geostoreId}&geostore_origin=${geostoreSource}`;
-    }
-
     async getDownloadURLs(startDate: string, endDate: string, params: Record<string, any>): Promise<{ csv: string, json: string }> {
         let areaIso: Record<string, any> = {};
         let area: Record<string, any>;
@@ -183,16 +210,29 @@ class ViirsPresenter extends PresenterInterface<ViirsActiveFiresAlertResultType,
         }
 
         const iso: Record<string, any> = Object.keys(areaIso).length && areaIso?.country ? areaIso : params.iso;
-
         const updatedParams: Record<string, any> = {...params, iso};
-        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
 
-        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
-        const uri: string = ViirsPresenter.getURLInPeriodForDownload(startDate, endDate, geostoreId, geostoreSource);
+        let uri: string;
+        if (AreaService.areaIsAdminBoundary(area, { provider: 'gadm', version: '4.1' })) {
+            uri = this.buildAdminURL(updatedParams, startDate, endDate);
+        } else {
+            uri = await this.buildGeostoreURL(area, updatedParams, startDate, endDate);
+        }
+
         return {
             csv: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'csv'),
             json: `${config.get('dataApi.url')}${uri}`.replace('{format}', 'json'),
         };
+    }
+
+    private async buildGeostoreURL(area: Record<string, any>, updatedParams: Record<string, any>, startDate: string, endDate: string): Promise<string> {
+        const geostoreSource: 'gfw' | 'rw' = area ? AreaService.getGeostoreSource(area) : 'rw';
+        const geostoreId: string = await GeostoreService.getGeostoreIdFromSubscriptionParams(updatedParams);
+        return ViirsPresenter.getURLInPeriodForDownload(startDate, endDate, geostoreId, geostoreSource);
+    }
+
+    private buildAdminURL(params: Record<string, any>, startDate: string, endDate: string):string {
+        return ViirsPresenter.#getAdminURLForDownload(startDate, endDate, params);
     }
 
     async transform(results: AlertResultWithCount<ViirsActiveFiresAlertResultType>, subscription: ISubscription, layer: ILayer, begin: Date, end: Date): Promise<ViirsPresenterResponse> {

--- a/test/e2e/email-notifications/glad-alerts-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-emails.spec.ts
@@ -73,7 +73,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -120,7 +124,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-fr':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -168,7 +176,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-zh':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -219,7 +231,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -271,7 +287,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -324,7 +344,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -346,6 +370,182 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
             begin_date: beginDate,
             end_date: endDate
         }));
+    });
+
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('GLAD alert emails for admin 0 subscriptions work as expected', async () => {
+            const country = 'BRA'
+            const areaId = getUUID()
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-alerts',
+                { params: { iso: { country, source: { provider: 'gadm', version: '4.1' }}, area: areaId} },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, source: { provider: 'gadm', version: '4.1' } }, 2)
+
+            mockGLADLISOQuery();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.1',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD alert emails for admin 1 subscriptions work as expected', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const areaId = getUUID()
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-alerts',
+                { params: { iso: { country, region, source: { provider: 'gadm', version: '4.1' } }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, source: { provider: 'gadm', version: '4.1' } }, 2)
+
+            mockGLADLAdm1Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.01',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD alert emails for admin 2 subscriptions work as expected', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const subregion = '2'
+            const areaId = getUUID()
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-alerts',
+                { params: { iso: { country, region, subregion, source: { provider: 'gadm', version: '4.1' } }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, subregion, source: { provider: 'gadm', version: '4.1' } }, 2);
+
+            mockGLADLAdm2Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[subregion]': '2',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.001',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
     });
 
     it('GLAD alert emails for WDPA subscriptions work as expected', async () => {
@@ -372,7 +572,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -420,7 +624,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -497,7 +705,11 @@ describe('GLAD-ALL emails (existing "glad-alerts" subscriptions should now use "
                 case 'glad-updated-notification-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate,
+                    validateGladL(jsonMessage, subscriptionOne, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',

--- a/test/e2e/email-notifications/glad-alerts-l-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-l-emails.spec.ts
@@ -64,6 +64,7 @@ describe('GLAD-L alerts', () => {
         const { beginDate, endDate } = bootstrapEmailNotificationTests();
         createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
         createMockArea(areaId, { country }, 2)
+
         mockGLADLISOQuery();
 
         redisClient.subscribe(CHANNEL, (message) => {
@@ -74,7 +75,11 @@ describe('GLAD-L alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, sub, beginDate, endDate,
+                    validateGladL(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -122,7 +127,11 @@ describe('GLAD-L alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, sub, beginDate, endDate,
+                    validateGladL(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -171,7 +180,11 @@ describe('GLAD-L alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, sub, beginDate, endDate,
+                    validateGladL(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -217,7 +230,11 @@ describe('GLAD-L alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, sub, beginDate, endDate,
+                    validateGladL(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -261,7 +278,11 @@ describe('GLAD-L alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladL(jsonMessage, sub, beginDate, endDate,
+                    validateGladL(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -286,12 +307,181 @@ describe('GLAD-L alerts', () => {
         }));
     });
 
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('GLAD-L alerts matches "glad-l" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA';
+            const areaId = getUUID();
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-l',
+                {params: {iso: {country, source: {provider: 'gadm', version: '4.1'}}, area: areaId}},
+            )).save();
+
+            const {beginDate, endDate} = bootstrapEmailNotificationTests();
+            createMockArea(areaId, {country, source: {provider: 'gadm', version: '4.1'}}, 2);
+
+            mockGLADLISOQuery();
+
+            await redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladL(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.1',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+
+        it('GLAD-L alerts matches "glad-l" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const areaId = getUUID()
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-l',
+                {params: {iso: {country, region, source: { provider: 'gadm', version: '4.1'}}, area: areaId}},
+            )).save();
+
+            const {beginDate, endDate} = bootstrapEmailNotificationTests();
+            createMockArea(areaId, {country, region, source: { provider: 'gadm', version: '4.1'} }, 2)
+
+            mockGLADLAdm1Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladL(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.01',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD-L alerts matches "glad-l" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const subregion = '2'
+            const areaId = getUUID()
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-l',
+                {params: {iso: {country, region, subregion, source: { provider: 'gadm', version: '4.1'}}, area: areaId}},
+            )).save();
+
+            const {beginDate, endDate} = bootstrapEmailNotificationTests();
+            createMockArea(areaId, {country, region, subregion, source: { provider: 'gadm', version: '4.1'}}, 2)
+
+            mockGLADLAdm2Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladL(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[subregion]': '2',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.001',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+    });
     afterEach(async () => {
         await redisClient.unsubscribe(CHANNEL);
         process.removeAllListeners('unhandledRejection');
 
         if (!nock.isDone()) {
-            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+           throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
         }
 
         await Subscription.deleteMany({}).exec();

--- a/test/e2e/email-notifications/glad-alerts-radd-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-radd-emails.spec.ts
@@ -11,7 +11,6 @@ import { getTestServer } from '../utils/test-server';
 import { createSubscriptionContent, getUUID } from '../utils/helpers';
 import { createMockArea, createMockGeostore } from '../utils/mock';
 import { USERS } from '../utils/test.constants';
-import { mockGLADAllGeostoreQuery } from '../utils/mocks/gladAll.mocks';
 import {
     mockGLADRADDAdm1Query,
     mockGLADRADDAdm2Query, mockGLADRADDGeostoreQuery,
@@ -74,7 +73,11 @@ describe('GLAD-RADD alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladRadd(jsonMessage, sub, beginDate, endDate,
+                    validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -122,7 +125,11 @@ describe('GLAD-RADD alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladRadd(jsonMessage, sub, beginDate, endDate,
+                    validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -172,7 +179,11 @@ describe('GLAD-RADD alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladRadd(jsonMessage, sub, beginDate, endDate,
+                    validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -217,7 +228,11 @@ describe('GLAD-RADD alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladRadd(jsonMessage, sub, beginDate, endDate,
+                    validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -261,7 +276,11 @@ describe('GLAD-RADD alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladRadd(jsonMessage, sub, beginDate, endDate,
+                    validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -284,6 +303,173 @@ describe('GLAD-RADD alerts', () => {
             begin_date: beginDate,
             end_date: endDate
         }));
+    });
+
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('GLAD-RADD alerts matches "glad-radd" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA'
+            const areaId = getUUID()
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-radd',
+                { params: { iso: { country, source: {provider: 'gadm', version: '4.1'} }, area: areaId} },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 2)
+
+            mockGLADRADDISOQuery();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.1',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD-RADD alerts matches "glad-radd" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const areaId = getUUID()
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-radd',
+                { params: { iso: { country, region, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 2)
+
+            mockGLADRADDAdm1Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.01',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD-RADD alerts matches "glad-radd" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const subregion = '2'
+            const areaId = getUUID()
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-radd',
+                { params: { iso: { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 2)
+
+            mockGLADRADDAdm2Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladRadd(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[subregion]': '2',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.001',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
     });
 
     afterEach(async () => {

--- a/test/e2e/email-notifications/glad-alerts-s2-emails.spec.ts
+++ b/test/e2e/email-notifications/glad-alerts-s2-emails.spec.ts
@@ -74,7 +74,11 @@ describe('GLAD-S2 alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladS2(jsonMessage, sub, beginDate, endDate,
+                    validateGladS2(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -122,7 +126,11 @@ describe('GLAD-S2 alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladS2(jsonMessage, sub, beginDate, endDate,
+                    validateGladS2(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -171,7 +179,11 @@ describe('GLAD-S2 alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladS2(jsonMessage, sub, beginDate, endDate,
+                    validateGladS2(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -196,6 +208,173 @@ describe('GLAD-S2 alerts', () => {
         }));
     });
 
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('GLAD-S2 alerts matches "glad-s2" for admin0 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA';
+            const areaId = getUUID();
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-s2',
+                { params: { iso: { country, source: {provider: 'gadm', version: '4.1'} }, area: areaId} },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            mockGLADS2ISOQuery();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladS2(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.1',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD-S2 alerts matches "glad-s2" for admin1 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const areaId = getUUID();
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-s2',
+                { params: { iso: { country, region, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            mockGLADS2Adm1Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladS2(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.01',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('GLAD-S2 alerts matches "glad-s2" for admin2 subscriptions, using the correct email template and providing the needed data', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const subregion = '2';
+            const areaId = getUUID();
+            const sub = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'glad-s2',
+                { params: { iso: { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            mockGLADS2Adm2Query();
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'glad-updated-notification-en': {
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
+                        validateCustomMapURLs(jsonMessage);
+                        validateGladS2(jsonMessage, sub, beginDate, endDate, 'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[subregion]': '2',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.001',
+                            },
+                            {
+                                total: 400,
+                                area: '40',
+                                intactForestArea: '10',
+                                primaryForestArea: '10',
+                                peatArea: '10',
+                                wdpaArea: '10'
+                            });
+                        break;
+                    }
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+    });
+
     it('GLAD-S2 alerts matches "glad-s2" for WDPA subscriptions, using the correct email template and providing the needed data', async () => {
         const sub = await new Subscription(createSubscriptionContent(
             USERS.USER.id,
@@ -216,7 +395,11 @@ describe('GLAD-S2 alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladS2(jsonMessage, sub, beginDate, endDate,
+                    validateGladS2(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -261,7 +444,11 @@ describe('GLAD-S2 alerts', () => {
                 case 'glad-updated-notification-en': {
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, sub);
                     validateCustomMapURLs(jsonMessage);
-                    validateGladS2(jsonMessage, sub, beginDate, endDate,
+                    validateGladS2(jsonMessage, sub, beginDate, endDate, 'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
                         {
                             total: 400,
                             area: '40',
@@ -288,7 +475,6 @@ describe('GLAD-S2 alerts', () => {
 
     afterEach(async () => {
         await redisClient.unsubscribe(CHANNEL);
-        ;
         process.removeAllListeners('unhandledRejection');
 
         if (!nock.isDone()) {

--- a/test/e2e/email-notifications/monthly-summary-alerts-emails.spec.ts
+++ b/test/e2e/email-notifications/monthly-summary-alerts-emails.spec.ts
@@ -316,6 +316,151 @@ describe('Monthly summary notifications', () => {
         }));
     });
 
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('Monthly summary alert emails for subscriptions that refer to an ISO code work as expected', async () => {
+            const country = 'BRA';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'monthly-summary',
+                { params: { iso: { country, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
+            mockGLADLISOQuery(2);
+            mockVIIRSAlertsISOQuery(2);
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 4)
+
+            await redisClient.subscribe(CHANNEL, (message: string) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'monthly-summary-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateGLADSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateMonthlySummaryAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne, {
+                            other: 25,
+                            primary_forest: 175,
+                            protected_areas: 100
+                        });
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'monthly-summary',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('Monthly summary alert emails for subscriptions that refer to an ADM 1 region work as expected', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'monthly-summary',
+                { params: { iso: { country, region, source: {provider: 'gadm', version: '4.1'} }, area: areaId} },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
+            mockGLADLAdm1Query(2);
+            mockVIIRSAlertsISOQuery(2);
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 4);
+            await redisClient.subscribe(CHANNEL, (message: string) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'monthly-summary-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateGLADSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateMonthlySummaryAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne, {
+                            other: 25,
+                            primary_forest: 175,
+                            protected_areas: 100
+                        });
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'monthly-summary',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('Monthly summary alert emails for subscriptions that refer to an ADM 2 subregion work as expected', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const subregion = '2';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createSubscriptionContent(
+                USERS.USER.id,
+                'monthly-summary',
+                { params: { iso: { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
+            mockGLADLAdm2Query(2);
+            mockVIIRSAlertsISOQuery(2);
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 4);
+
+            await redisClient.subscribe(CHANNEL, (message: string) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'monthly-summary-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateGLADSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateMonthlySummaryAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne, {
+                            other: 25,
+                            primary_forest: 175,
+                            protected_areas: 100
+                        });
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'monthly-summary',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+    });
+
     it('Monthly summary alert emails for subscriptions that refer to a WDPA ID work as expected', async () => {
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');

--- a/test/e2e/email-notifications/viirs-fires-alerts-emails.spec.ts
+++ b/test/e2e/email-notifications/viirs-fires-alerts-emails.spec.ts
@@ -74,7 +74,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne);
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                    );
                     validateCustomMapURLs(jsonMessage);
                     break;
                 default:
@@ -132,7 +142,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-fr':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'moyenne');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne);
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                    );
                     validateCustomMapURLs(jsonMessage);
                     break;
                 default:
@@ -190,7 +210,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-zh':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, '平均');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne);
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                    );
                     validateCustomMapURLs(jsonMessage);
                     break;
                 default:
@@ -251,7 +281,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne, {
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                        {
                         intact_forest: 0,
                         other: 25,
                         peat: 0,
@@ -320,7 +360,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne, {
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                        {
                         intact_forest: 0,
                         other: 25,
                         peat: 0,
@@ -390,7 +440,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne, {
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                        {
                         intact_forest: 0,
                         other: 25,
                         peat: 0,
@@ -430,6 +490,257 @@ describe('VIIRS Fires alert emails', () => {
         return consumerPromise;
     });
 
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('VIIRS Fires emails for subscriptions that refer to an ISO code work as expected', async () => {
+            const country = 'BRA';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await createSubscription(
+                USERS.USER.id,
+                {
+                    datasets: ['viirs-active-fires'],
+                    params: { iso: { country, source: {provider: 'gadm', version: '4.1'} }, area: areaId }
+                }
+            );
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 3);
+
+            mockVIIRSAlertsISOQuery(2);
+
+            let expectedQueueMessageCount = 1;
+
+            const validateMailQueuedMessages = (resolve: (value: (PromiseLike<unknown> | unknown)) => void) => async (message: string) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'forest-fires-notification-viirs-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateVIIRSAlertsAndPriorityAreas(
+                            jsonMessage,
+                            beginDate,
+                            endDate,
+                            subscriptionOne,
+                            'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.1',
+                            },
+                            {
+                                intact_forest: 0,
+                                other: 25,
+                                peat: 0,
+                                plantations: 0,
+                                primary_forest: 75,
+                                protected_areas: 0,
+                            });
+                        validateCustomMapURLs(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+
+                expectedQueueMessageCount -= 1;
+
+                if (expectedQueueMessageCount < 0) {
+                    throw new Error(`Unexpected message count - expectedQueueMessageCount:${expectedQueueMessageCount}`);
+                }
+
+                if (expectedQueueMessageCount === 0) {
+                    resolve(null);
+                }
+            };
+
+            const consumerPromise = new Promise((resolve) => {
+                redisClient.subscribe(CHANNEL, validateMailQueuedMessages(resolve));
+            })
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'viirs-active-fires',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+
+            return consumerPromise;
+        });
+
+        it('VIIRS Fires emails for subscriptions that refer to an ADM 1 region work as expected', async () => {
+            const country = 'BRA';
+            const region = '3';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await createSubscription(
+                USERS.USER.id,
+                {
+                    datasets: ['viirs-active-fires'],
+                    params: { iso: { country, region, source: {provider: 'gadm', version: '4.1'} }, area: areaId }
+                }
+            );
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 3);
+
+            mockVIIRSAlertsISOQuery(2);
+
+            let expectedQueueMessageCount = 1;
+
+            const validateMailQueuedMessages = (resolve: (value: (PromiseLike<unknown> | unknown)) => void) => async (message: string) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'forest-fires-notification-viirs-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateVIIRSAlertsAndPriorityAreas(
+                            jsonMessage,
+                            beginDate,
+                            endDate,
+                            subscriptionOne,
+                            'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '3',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.01',
+                            },
+                            {
+                                intact_forest: 0,
+                                other: 25,
+                                peat: 0,
+                                plantations: 0,
+                                primary_forest: 75,
+                                protected_areas: 0,
+                            });
+                        validateCustomMapURLs(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+
+                expectedQueueMessageCount -= 1;
+
+                if (expectedQueueMessageCount < 0) {
+                    throw new Error(`Unexpected message count - expectedQueueMessageCount:${expectedQueueMessageCount}`);
+                }
+
+                if (expectedQueueMessageCount === 0) {
+                    resolve(null);
+                }
+            };
+
+            const consumerPromise = new Promise((resolve) => {
+                redisClient.subscribe(CHANNEL, validateMailQueuedMessages(resolve));
+            })
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'viirs-active-fires',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+
+            return consumerPromise;
+        });
+
+        it('VIIRS Fires emails for subscriptions that refer to an ADM 2 subregion work as expected', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const subregion = '2';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await createSubscription(
+                USERS.USER.id,
+                {
+                    datasets: ['viirs-active-fires'],
+                    params: { iso: { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, area: areaId },
+                }
+            );
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 3);
+
+            mockVIIRSAlertsISOQuery(2);
+
+            let expectedQueueMessageCount = 1;
+
+            const validateMailQueuedMessages = (resolve: (value: (PromiseLike<unknown> | unknown)) => void) => async (message: string) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'forest-fires-notification-viirs-en':
+                        validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
+                        validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
+                        validateVIIRSAlertsAndPriorityAreas(
+                            jsonMessage,
+                            beginDate,
+                            endDate,
+                            subscriptionOne,
+                            'download_by_aoi',
+                            {
+                                'aoi[type]': 'admin',
+                                'aoi[country]': 'BRA',
+                                'aoi[region]': '1',
+                                'aoi[subregion]': '2',
+                                'aoi[provider]': 'gadm',
+                                'aoi[version]': '4.1',
+                                'aoi[simplify]': '0.001',
+                            },
+                            {
+                                intact_forest: 0,
+                                other: 25,
+                                peat: 0,
+                                plantations: 0,
+                                primary_forest: 75,
+                                protected_areas: 0,
+                            });
+                        validateCustomMapURLs(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+
+                expectedQueueMessageCount -= 1;
+
+                if (expectedQueueMessageCount < 0) {
+                    throw new Error(`Unexpected message count - expectedQueueMessageCount:${expectedQueueMessageCount}`);
+                }
+
+                if (expectedQueueMessageCount === 0) {
+                    resolve(null);
+                }
+            };
+
+            const consumerPromise = new Promise((resolve) => {
+                redisClient.subscribe(CHANNEL, validateMailQueuedMessages(resolve));
+            })
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'viirs-active-fires',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+
+            return consumerPromise;
+        });
+    });
+
     it('VIIRS Fires emails for subscriptions that refer to a WDPA ID work as expected', async () => {
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');
@@ -455,7 +766,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne, {
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                        {
                         intact_forest: 0,
                         other: 0,
                         peat: 0,
@@ -520,7 +841,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne);
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                    );
                     validateCustomMapURLs(jsonMessage);
                     break;
                 default:
@@ -827,7 +1158,17 @@ describe('VIIRS Fires alert emails', () => {
                 case 'forest-fires-notification-viirs-en':
                     validateCommonNotificationParams(jsonMessage, beginDate, endDate, subscriptionOne);
                     validateVIIRSSpecificParams(jsonMessage, beginDate, endDate, subscriptionOne, 'average');
-                    validateVIIRSAlertsAndPriorityAreas(jsonMessage, beginDate, endDate, subscriptionOne);
+                    validateVIIRSAlertsAndPriorityAreas(
+                        jsonMessage,
+                        beginDate,
+                        endDate,
+                        subscriptionOne,
+                        'download',
+                        {
+                            geostore_id: '423e5dfb0448e692f97b590c61f45f22',
+                            geostore_origin: 'rw',
+                        },
+                    );
                     validateCustomMapURLs(jsonMessage);
                     break;
                 default:

--- a/test/e2e/url-notifications/glad-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/glad-alerts-urls.spec.ts
@@ -141,9 +141,14 @@ describe('GLAD alert - URL Subscriptions', () => {
         mockGLADLISOQuery();
         createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
         createMockArea(areaId, { country }, 2);
-        createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
-            selected_area: 'ISO Code: BRA',
-        }));
+        createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(
+            subscriptionOne,
+            beginDate,
+            endDate,
+            'download',
+            '&geostore_origin=rw&geostore_id=423e5dfb0448e692f97b590c61f45f22',
+            { selected_area: 'ISO Code: BRA',}
+        ));
 
         redisClient.subscribe(CHANNEL, (message) => {
             const jsonMessage = JSON.parse(message);
@@ -182,9 +187,14 @@ describe('GLAD alert - URL Subscriptions', () => {
         createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
         createMockArea(areaId, { country, region }, 2);
 
-        createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
-            selected_area: 'ISO Code: BRA, ID1: 1',
-        }));
+        createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(
+            subscriptionOne,
+            beginDate,
+            endDate,
+            'download',
+            '&geostore_origin=rw&geostore_id=423e5dfb0448e692f97b590c61f45f22',
+            { selected_area: 'ISO Code: BRA, ID1: 1', }
+        ));
 
         redisClient.subscribe(CHANNEL, (message) => {
             const jsonMessage = JSON.parse(message);
@@ -224,9 +234,14 @@ describe('GLAD alert - URL Subscriptions', () => {
         createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
         createMockArea(areaId, { country, region, subregion }, 2);
 
-        createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
-            selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2',
-        }));
+        createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(
+            subscriptionOne,
+            beginDate,
+            endDate,
+            'download',
+            '&geostore_origin=rw&geostore_id=423e5dfb0448e692f97b590c61f45f22',
+            { selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2', }
+        ));
 
         redisClient.subscribe(CHANNEL, (message) => {
             const jsonMessage = JSON.parse(message);
@@ -248,6 +263,142 @@ describe('GLAD alert - URL Subscriptions', () => {
             begin_date: beginDate,
             end_date: endDate
         }));
+    });
+
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('Updating GLAD alerts dataset triggers the configured subscription url being called using the correct body data - ISO code for country', async () => {
+            const country = 'BRA'
+            const areaId = getUUID()
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'glad-alerts',
+                { params: { iso: { country, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            mockGLADLISOQuery();
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 2);
+            createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(
+                subscriptionOne,
+                beginDate,
+                endDate,
+                'download_by_aoi',
+                '&aoi[type]=admin&aoi[country]=BRA&aoi[provider]=gadm&aoi[version]=4.1&aoi[simplify]=0.1',
+                { selected_area: 'ISO Code: BRA', },
+            ));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('Updating GLAD alerts dataset triggers the configured subscription url being called using the correct body data - ISO code for country and region', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const areaId = getUUID()
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'glad-alerts',
+                { params: { iso: { country, region, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            mockGLADLAdm1Query();
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(
+                subscriptionOne,
+                beginDate,
+                endDate,
+                'download_by_aoi',
+                '&aoi[type]=admin&aoi[country]=BRA&aoi[region]=1&aoi[provider]=gadm&aoi[version]=4.1&aoi[simplify]=0.01',
+                { selected_area: 'ISO Code: BRA, ID1: 1', }
+            ));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('Updating GLAD alerts dataset triggers the configured subscription url being called using the correct body data - ISO code for country, region and subregion', async () => {
+            const country = 'BRA'
+            const region = '1'
+            const subregion = '2'
+            const areaId = getUUID()
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'glad-alerts',
+                { params: { iso: { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            mockGLADLAdm2Query();
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 2);
+
+            createURLSubscriptionCallMock(createGLADAlertsISOURLSubscriptionBody(
+                subscriptionOne,
+                beginDate,
+                endDate,
+                'download_by_aoi',
+                '&aoi[type]=admin&aoi[country]=BRA&aoi[region]=1&aoi[subregion]=2&aoi[provider]=gadm&aoi[version]=4.1&aoi[simplify]=0.001',
+                { selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2', }
+            ));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+                jsonMessage.should.have.property('template');
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'glad-alerts',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
     });
 
     it('Updating GLAD alerts dataset triggers the configured subscription url being called using the correct body data - WDPA ID', async () => {

--- a/test/e2e/url-notifications/monthly-summary-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/monthly-summary-alerts-urls.spec.ts
@@ -275,6 +275,143 @@ describe('Monthly summary notifications - URL Subscriptions', () => {
         }));
     });
 
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('Monthly summary alert for url subscriptions that refer to an ISO code work as expected', async () => {
+            const country = 'BRA';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'monthly-summary',
+                { params: { iso: { country, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
+            mockGLADLISOQuery(2);
+            mockVIIRSAlertsISOQuery(2);
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 4);
+
+            createURLSubscriptionCallMock(createMonthlySummaryISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
+                selected_area: 'ISO Code: BRA',
+            }));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'monthly-summary',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('Monthly summary alert for url subscriptions that refer to an ADM 1 region work as expected', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'monthly-summary',
+                { params: { iso: { country, region, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
+            mockGLADLAdm1Query(2);
+            mockVIIRSAlertsISOQuery(2);
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 4);
+
+            createURLSubscriptionCallMock(createMonthlySummaryISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
+                selected_area: 'ISO Code: BRA, ID1: 1',
+            }));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'monthly-summary',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('Monthly summary alert for url subscriptions that refer to an ADM 2 subregion work as expected', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const subregion = '2';
+            const areaId = getUUID()
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'monthly-summary',
+                { params: { iso: { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests('1', 'month');
+            mockGLADLAdm2Query(2);
+            mockVIIRSAlertsISOQuery(2);
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 4);
+
+            createURLSubscriptionCallMock(createMonthlySummaryISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
+                selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2',
+            }));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'monthly-summary',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+    });
+
     it('Monthly summary alert for url subscriptions that refer to a WDPA ID work as expected', async () => {
         EmailHelpersService.updateMonthTranslations();
         moment.locale('en');

--- a/test/e2e/url-notifications/viirs-fires-alerts-urls.spec.ts
+++ b/test/e2e/url-notifications/viirs-fires-alerts-urls.spec.ts
@@ -145,9 +145,14 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
         createMockGeostore(`/geostore/admin/${country}`, config.get('dataApi.url'));
         createMockArea(areaId, { country }, 3);
 
-        createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
-            selected_area: 'ISO Code: BRA',
-        }));
+        createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(
+                subscriptionOne,
+                beginDate,
+                endDate,
+                'download',
+                '&geostore_id=423e5dfb0448e692f97b590c61f45f22&geostore_origin=rw',
+                { selected_area: 'ISO Code: BRA', }
+        ));
 
         redisClient.subscribe(CHANNEL, (message) => {
             const jsonMessage = JSON.parse(message);
@@ -191,9 +196,14 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
         createMockGeostore(`/geostore/admin/${country}/${region}`, config.get('dataApi.url'));
         createMockArea(areaId, { country, region }, 3);
 
-        createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
-            selected_area: 'ISO Code: BRA, ID1: 3',
-        }));
+        createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(
+            subscriptionOne,
+            beginDate,
+            endDate,
+            'download',
+            '&geostore_id=423e5dfb0448e692f97b590c61f45f22&geostore_origin=rw',
+            { selected_area: 'ISO Code: BRA, ID1: 3', }
+        ));
 
         redisClient.subscribe(CHANNEL, (message) => {
             const jsonMessage = JSON.parse(message);
@@ -236,9 +246,14 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
         mockVIIRSAlertsISOQuery(2, config.get('datasets.viirsISODataset'));
         createMockGeostore(`/geostore/admin/${country}/${region}/${subregion}`, config.get('dataApi.url'));
         createMockArea(areaId, { country, region, subregion }, 3);
-        createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(subscriptionOne, beginDate, endDate, {
-            selected_area: 'ISO Code: BRA, ID1: 1, ID2: 1',
-        }));
+        createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(
+            subscriptionOne,
+            beginDate,
+            endDate,
+            'download',
+            '&geostore_id=423e5dfb0448e692f97b590c61f45f22&geostore_origin=rw',
+            { selected_area: 'ISO Code: BRA, ID1: 1, ID2: 1',}
+        ));
 
         redisClient.subscribe(CHANNEL, (message) => {
             const jsonMessage = JSON.parse(message);
@@ -262,6 +277,155 @@ describe('VIIRS Fires alert - URL Subscriptions', () => {
             begin_date: beginDate,
             end_date: endDate
         }));
+    });
+
+    describe('GADM 4.1 Administrative Areas @gadm4_1', () => {
+        it('VIIRS Fires emails for subscriptions that refer to an ISO code work as expected', async () => {
+            const country = 'BRA';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'viirs-active-fires',
+                { params: { iso: { country, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            mockVIIRSAlertsISOQuery(2, config.get('datasets.viirsISODataset'));
+            createMockArea(areaId, { country, source: {provider: 'gadm', version: '4.1'} }, 3);
+
+            createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(
+                subscriptionOne,
+                beginDate,
+                endDate,
+                'download_by_aoi',
+                '&aoi[type]=admin&aoi[country]=BRA&aoi[provider]=gadm&aoi[version]=4.1&aoi[simplify]=0.1',
+                { selected_area: 'ISO Code: BRA', }
+            ));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'viirs-active-fires',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('VIIRS Fires emails for subscriptions that refer to an ISO region work as expected', async () => {
+            const country = 'BRA';
+            const region = '3';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'viirs-active-fires',
+                { params: { iso: { country, region, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            mockVIIRSAlertsISOQuery(2, config.get('datasets.viirsISODataset'));
+            createMockArea(areaId, { country, region, source: {provider: 'gadm', version: '4.1'} }, 3);
+
+            createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(
+                subscriptionOne,
+                beginDate,
+                endDate,
+                'download_by_aoi',
+                '&aoi[type]=admin&aoi[country]=BRA&aoi[region]=3&aoi[provider]=gadm&aoi[version]=4.1&aoi[simplify]=0.01',
+                { selected_area: 'ISO Code: BRA, ID1: 3', }
+            ));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'viirs-active-fires',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
+
+        it('VIIRS Fires emails for subscriptions that refer to an ISO subregion work as expected', async () => {
+            const country = 'BRA';
+            const region = '1';
+            const subregion = '2';
+            const areaId = getUUID();
+            EmailHelpersService.updateMonthTranslations();
+            moment.locale('en');
+            const subscriptionOne = await new Subscription(createURLSubscription(
+                USERS.USER.id,
+                'viirs-active-fires',
+                { params: { iso: { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, area: areaId } },
+            )).save();
+
+            const { beginDate, endDate } = bootstrapEmailNotificationTests();
+            mockVIIRSAlertsISOQuery(2, config.get('datasets.viirsISODataset'));
+            createMockArea(areaId, { country, region, subregion, source: {provider: 'gadm', version: '4.1'} }, 3);
+            createURLSubscriptionCallMock(createViirsFireAlertsISOURLSubscriptionBody(
+                subscriptionOne,
+                beginDate,
+                endDate,
+                'download_by_aoi',
+                '&aoi[type]=admin&aoi[country]=BRA&aoi[region]=1&aoi[subregion]=2&aoi[provider]=gadm&aoi[version]=4.1&aoi[simplify]=0.001',
+                { selected_area: 'ISO Code: BRA, ID1: 1, ID2: 2',}
+            ));
+
+            redisClient.subscribe(CHANNEL, (message) => {
+                const jsonMessage = JSON.parse(message);
+
+                jsonMessage.should.have.property('template');
+
+                switch (jsonMessage.template) {
+
+                    case 'subscriptions-stats':
+                        assertSubscriptionStatsNotificationEvent(jsonMessage);
+                        break;
+                    default:
+                        should.fail('Unsupported message type: ', jsonMessage.template);
+                        break;
+
+                }
+            });
+
+            await AlertQueue.processMessage(JSON.stringify({
+                layer_slug: 'viirs-active-fires',
+                begin_date: beginDate,
+                end_date: endDate
+            }));
+        });
     });
 
     it('VIIRS Fires emails for subscriptions that refer to a WDPA ID work as expected', async () => {

--- a/test/e2e/utils/helpers/email-notifications.ts
+++ b/test/e2e/utils/helpers/email-notifications.ts
@@ -49,7 +49,14 @@ export const validateCommonNotificationParams = (jsonMessage: Record<string, any
     jsonMessage.data.should.have.property('help_center_url_investigate_alerts', `${config.get('gfw.flagshipUrl')}/help/map/guides/investigate-forest-change-satellite-imagery?lang=${sub.language}`);
 };
 
-export const validateVIIRSAlertsAndPriorityAreas = (jsonMessage: Record<string, any>, beginDate: Moment, endDate: Moment, sub: ISubscription, priorityOverride = {}) => {
+export const validateVIIRSAlertsAndPriorityAreas = (
+    jsonMessage: Record<string, any>,
+    beginDate: Moment,
+    endDate: Moment,
+    sub: ISubscription,
+    downloadEndpoint: string,
+    expectedQueryParameters: Record<string, string>,
+    priorityOverride = {}) => {
     jsonMessage.data.should.have.property('layerSlug').and.equal('viirs-active-fires');
 
     // Validate download URLs
@@ -58,25 +65,37 @@ export const validateVIIRSAlertsAndPriorityAreas = (jsonMessage: Record<string, 
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
         .and.contain(config.get('datasets.viirsDownloadDataset'))
-        .and.contain('download/csv')
+        .and.contain(`${downloadEndpoint}/csv`)
         .and.contain('SELECT latitude, longitude, alert__date, confidence__cat')
         .and.contain(', is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest')
         .and.contain(', is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> \'\' THEN \'True\' ELSE \'False\' END as in_protected_areas')
         .and.contain(`FROM ${config.get('datasets.viirsDownloadDataset')}`)
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const csvUrl = new URL(jsonMessage.data.downloadUrls['csv']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = csvUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     jsonMessage.data.downloadUrls.should.have.property('json')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
         .and.contain(config.get('datasets.viirsDownloadDataset'))
-        .and.contain('download/json')
+        .and.contain(`${downloadEndpoint}/json`)
         .and.contain('SELECT latitude, longitude, alert__date, confidence__cat')
         .and.contain(', is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest')
         .and.contain(', is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> \'\' THEN \'True\' ELSE \'False\' END as in_protected_areas')
         .and.contain(`FROM ${config.get('datasets.viirsDownloadDataset')}`)
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const jsonUrl = new URL(jsonMessage.data.downloadUrls['json']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = jsonUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     const priorityAreas = {
         intact_forest: 0,
@@ -275,6 +294,8 @@ export const validateGladL = (
     sub: ISubscription,
     beginDate: Moment,
     endDate: Moment,
+    downloadEndpoint: string,
+    expectedQueryParameters: Record<string, string>,
     {
         total, area, intactForestArea, primaryForestArea, peatArea, wdpaArea, lang = 'en'
     }: {
@@ -288,18 +309,30 @@ export const validateGladL = (
     jsonMessage.data.downloadUrls.should.have.property('csv')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/umd_glad_landsat_alerts/latest/download/csv')
+        .and.contain(`/dataset/umd_glad_landsat_alerts/latest/${downloadEndpoint}/csv`)
         .and.contain('SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const csvUrl = new URL(jsonMessage.data.downloadUrls['csv']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = csvUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     jsonMessage.data.downloadUrls.should.have.property('json')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/umd_glad_landsat_alerts/latest/download/json')
+        .and.contain(`/dataset/umd_glad_landsat_alerts/latest/${downloadEndpoint}/json`)
         .and.contain('SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const jsonUrl = new URL(jsonMessage.data.downloadUrls['json']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = jsonUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     jsonMessage.data.should.have.property('alert_count').and.equal(total);
     jsonMessage.data.should.have.property('value').and.equal(total);
@@ -335,6 +368,8 @@ export const validateGladS2 = (
     sub: ISubscription,
     beginDate: Moment,
     endDate: Moment,
+    downloadEndpoint: string,
+    expectedQueryParameters: Record<string, string>,
     {
         total, area, intactForestArea, primaryForestArea, peatArea, wdpaArea, lang = 'en'
     }: {
@@ -348,18 +383,30 @@ export const validateGladS2 = (
     jsonMessage.data.downloadUrls.should.have.property('csv')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/gfw_integrated_alerts/latest/download/csv')
+        .and.contain(`/dataset/gfw_integrated_alerts/latest/${downloadEndpoint}/csv`)
         .and.contain('SELECT latitude, longitude, umd_glad_sentinel2_alerts__date, umd_glad_sentinel2_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const csvUrl = new URL(jsonMessage.data.downloadUrls['csv']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = csvUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     jsonMessage.data.downloadUrls.should.have.property('json')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/gfw_integrated_alerts/latest/download/json')
+        .and.contain(`/dataset/gfw_integrated_alerts/latest/${downloadEndpoint}/json`)
         .and.contain('SELECT latitude, longitude, umd_glad_sentinel2_alerts__date, umd_glad_sentinel2_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const jsonUrl = new URL(jsonMessage.data.downloadUrls['json']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = jsonUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     jsonMessage.data.should.have.property('alert_count').and.equal(total);
     jsonMessage.data.should.have.property('value').and.equal(total);
@@ -395,6 +442,8 @@ export const validateGladRadd = (
     sub: ISubscription,
     beginDate: Moment,
     endDate: Moment,
+    downloadEndpoint: string,
+    expectedQueryParameters: Record<string, string>,
     {
         total, area, intactForestArea, primaryForestArea, peatArea, wdpaArea, lang = 'en'
     }: {
@@ -408,18 +457,30 @@ export const validateGladRadd = (
     jsonMessage.data.downloadUrls.should.have.property('csv')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/gfw_integrated_alerts/latest/download/csv')
+        .and.contain(`/dataset/gfw_integrated_alerts/latest/${downloadEndpoint}/csv`)
         .and.contain('SELECT latitude, longitude, wur_radd_alerts__date, wur_radd_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const csvUrl = new URL(jsonMessage.data.downloadUrls['csv']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = csvUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     jsonMessage.data.downloadUrls.should.have.property('json')
         .and.be.a('string')
         .and.contain(config.get('dataApi.url'))
-        .and.contain('/dataset/gfw_integrated_alerts/latest/download/json')
+        .and.contain(`/dataset/gfw_integrated_alerts/latest/${downloadEndpoint}/json`)
         .and.contain('SELECT latitude, longitude, wur_radd_alerts__date, wur_radd_alerts__confidence')
-        .and.contain('&geostore_id=')
-        .and.contain('&geostore_origin=rw');
+
+    // Validate each expected parameter
+    const jsonUrl = new URL(jsonMessage.data.downloadUrls['json']);
+    Object.entries(expectedQueryParameters).forEach(([key, value]) => {
+        const param = jsonUrl.searchParams.get(key);
+        expect(param).to.not.eq(null, `${key} is missing from query parameters`);
+        expect(param).to.eq(value, `query parameter: ${key}`);
+    });
 
     jsonMessage.data.should.have.property('alert_count').and.equal(total);
     jsonMessage.data.should.have.property('value').and.equal(total);

--- a/test/e2e/utils/mocks/glad.mocks.ts
+++ b/test/e2e/utils/mocks/glad.mocks.ts
@@ -274,7 +274,7 @@ export const createGLADAlertsWDPAURLSubscriptionBody = (subscription: Record<str
     };
 };
 
-export const createGLADAlertsISOURLSubscriptionBody = (subscription: Record<string, any>, beginDate: Moment, endDate: Moment, bodyData: Record<string, any> = {}) => {
+export const createGLADAlertsISOURLSubscriptionBody = (subscription: Record<string, any>, beginDate: Moment, endDate: Moment, downloadEndpoint: string, downloadQueryParams: string, bodyData: Record<string, any> = {}) => {
     const mapURLIntactForestQueryString = {
         lang: subscription.language,
         map: btoa(JSON.stringify({
@@ -528,8 +528,8 @@ export const createGLADAlertsISOURLSubscriptionBody = (subscription: Record<stri
         peat_ha_sum: "10",
         wdpa_ha_sum: "10",
         downloadUrls: {
-            csv: `${config.get('dataApi.url')}/dataset/umd_glad_landsat_alerts/latest/download/csv?sql=SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence FROM data WHERE umd_glad_landsat_alerts__date >= '${beginDate.format('YYYY-MM-DD')}' AND umd_glad_landsat_alerts__date <= '${endDate.format('YYYY-MM-DD')}'&geostore_origin=rw&geostore_id=423e5dfb0448e692f97b590c61f45f22`,
-            json: `${config.get('dataApi.url')}/dataset/umd_glad_landsat_alerts/latest/download/json?sql=SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence FROM data WHERE umd_glad_landsat_alerts__date >= '${beginDate.format('YYYY-MM-DD')}' AND umd_glad_landsat_alerts__date <= '${endDate.format('YYYY-MM-DD')}'&geostore_origin=rw&geostore_id=423e5dfb0448e692f97b590c61f45f22`
+            csv: `${config.get('dataApi.url')}/dataset/umd_glad_landsat_alerts/latest/${downloadEndpoint}/csv?sql=SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence FROM data WHERE umd_glad_landsat_alerts__date >= '${beginDate.format('YYYY-MM-DD')}' AND umd_glad_landsat_alerts__date <= '${endDate.format('YYYY-MM-DD')}'${downloadQueryParams}`,
+            json: `${config.get('dataApi.url')}/dataset/umd_glad_landsat_alerts/latest/${downloadEndpoint}/json?sql=SELECT latitude, longitude, umd_glad_landsat_alerts__date, umd_glad_landsat_alerts__confidence FROM data WHERE umd_glad_landsat_alerts__date >= '${beginDate.format('YYYY-MM-DD')}' AND umd_glad_landsat_alerts__date <= '${endDate.format('YYYY-MM-DD')}'${downloadQueryParams}`
         },
         glad_alert_type: 'GLAD-L deforestation alerts',
         layerSlug: 'glad-alerts',

--- a/test/e2e/utils/mocks/viirs.mocks.ts
+++ b/test/e2e/utils/mocks/viirs.mocks.ts
@@ -555,7 +555,7 @@ export const createViirsFireAlertsGeostoreURLSubscriptionBody = (subscription: R
     };
 };
 
-export const createViirsFireAlertsISOURLSubscriptionBody = (subscription: Record<string, any>, beginDate: Moment, endDate: Moment, bodyData: Record<string, any> = {}) => {
+export const createViirsFireAlertsISOURLSubscriptionBody = (subscription: Record<string, any>, beginDate: Moment, endDate: Moment, downloadEndpoint: string, downloadQueryParams: string, bodyData: Record<string, any> = {}) => {
     const mapURLIntactForestQueryString = {
         lang: subscription.language,
         map: btoa(JSON.stringify({
@@ -791,8 +791,8 @@ export const createViirsFireAlertsISOURLSubscriptionBody = (subscription: Record
         viirs_count: 100,
         alert_count: 100,
         downloadUrls: {
-            csv: `${config.get('dataApi.url')}/dataset/nasa_viirs_fire_alerts/latest/download/csv?sql=SELECT latitude, longitude, alert__date, confidence__cat, is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest, is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> '' THEN 'True' ELSE 'False' END as in_protected_areas FROM nasa_viirs_fire_alerts WHERE alert__date > '${beginDate.format('YYYY-MM-DD')}' AND alert__date <= '${endDate.format('YYYY-MM-DD')}'&geostore_id=423e5dfb0448e692f97b590c61f45f22&geostore_origin=rw`,
-            json: `${config.get('dataApi.url')}/dataset/nasa_viirs_fire_alerts/latest/download/json?sql=SELECT latitude, longitude, alert__date, confidence__cat, is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest, is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> '' THEN 'True' ELSE 'False' END as in_protected_areas FROM nasa_viirs_fire_alerts WHERE alert__date > '${beginDate.format('YYYY-MM-DD')}' AND alert__date <= '${endDate.format('YYYY-MM-DD')}'&geostore_id=423e5dfb0448e692f97b590c61f45f22&geostore_origin=rw`
+            csv: `${config.get('dataApi.url')}/dataset/nasa_viirs_fire_alerts/latest/${downloadEndpoint}/csv?sql=SELECT latitude, longitude, alert__date, confidence__cat, is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest, is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> '' THEN 'True' ELSE 'False' END as in_protected_areas FROM nasa_viirs_fire_alerts WHERE alert__date > '${beginDate.format('YYYY-MM-DD')}' AND alert__date <= '${endDate.format('YYYY-MM-DD')}'${downloadQueryParams}`,
+            json: `${config.get('dataApi.url')}/dataset/nasa_viirs_fire_alerts/latest/${downloadEndpoint}/json?sql=SELECT latitude, longitude, alert__date, confidence__cat, is__ifl_intact_forest_landscape_2016 as in_intact_forest, is__umd_regional_primary_forest_2001 as in_primary_forest, is__peatland as in_peat, CASE WHEN wdpa_protected_area__iucn_cat <> '' THEN 'True' ELSE 'False' END as in_protected_areas FROM nasa_viirs_fire_alerts WHERE alert__date > '${beginDate.format('YYYY-MM-DD')}' AND alert__date <= '${endDate.format('YYYY-MM-DD')}'${downloadQueryParams}`
         },
         priority_areas: {
             intact_forest: 0,


### PR DESCRIPTION
[GTC-3261](https://gfw.atlassian.net/browse/GTC-3261)

Instead of using `geostore_id` to create download URLs for email alerts, now [we use the new](https://gfw.atlassian.net/browse/GTC-3260) `geostore_by_aoi` endpoint. This endpoint takes administrative boundary IDs and is used solely with GADM 4.1 areas.

This PR finishes what #183 started.