### PR TITLE
fix(map-link): change dataset and layers ids to fix map link

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -35,15 +35,18 @@
     "viirsDownloadDataset": "nasa_viirs_fire_alerts"
   },
   "layers": {
-    "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",
-    "gladAlertLayer": "8e4a527d-1bcd-4a12-82b0-5a108ffec452",
-    "umdLossGainLayerDataset": "eab9655f-dd37-4bb3-b223-4c5df166564c",
-    "umdLossGainLayer": "dce8004f-4d0f-4c2d-ae4b-dcf55e14035f",
+    "gladAlertLayerDataset": "integrated-deforestation-alerts-8bit",
+    "gladAlertLayer": "integrated-deforestation-alerts-8bit",
+    "gladLAlertLayer": "integrated-deforestation-alerts-8bit-gladL",
+    "gladRaddAlertLayer": "integrated-deforestation-alerts-8bit-radd",
+    "gladSAlertLayer": "integrated-deforestation-alerts-8bit-s",
+    "umdLossGainLayerDataset": "tree-cover-loss",
+    "umdLossGainLayer": "tree-cover-loss",
     "viirsLayerDataset": "fire-alerts-viirs",
     "viirsLayer": "fire-alerts-viirs",
-    "gadm36BoundariesDataset": "0b0208b6-b424-4b57-984f-caddfa25ba22",
-    "gadm36BoundariesLayer1": "b45350e3-5a76-44cd-b0a9-5038a0d8bfae",
-    "gadm36BoundariesLayer2": "cc35432d-38d7-4a03-872e-3a71a2f555fc"
+    "gadm36BoundariesDataset": "political-boundaries",
+    "gadm36BoundariesLayer1": "political-boundaries",
+    "gadm36BoundariesLayer2": "disputed-political-boundaries"
   },
   "dataApi": {
     "url": "https://staging-data-api.globalforestwatch.org"

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,13 +1,16 @@
 {
   "layers": {
-    "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",
-    "gladAlertLayer": "8e4a527d-1bcd-4a12-82b0-5a108ffec452",
-    "umdLossGainLayerDataset": "b584954c-0d8d-40c6-859c-f3fdf3c2c5df",
-    "umdLossGainLayer": "49a80e70-ec52-4ef8-bcc6-fb2771d95b2c",
+    "gladAlertLayerDataset": "integrated-deforestation-alerts-8bit",
+    "gladAlertLayer": "integrated-deforestation-alerts-8bit",
+    "gladLAlertLayer": "integrated-deforestation-alerts-8bit-gladL",
+    "gladRaddAlertLayer": "integrated-deforestation-alerts-8bit-radd",
+    "gladSAlertLayer": "integrated-deforestation-alerts-8bit-s",
+    "umdLossGainLayerDataset": "tree-cover-loss",
+    "umdLossGainLayer": "tree-cover-loss",
     "viirsLayerDataset": "fire-alerts-viirs",
     "viirsLayer": "fire-alerts-viirs",
-    "gadm36BoundariesDataset": "0b0208b6-b424-4b57-984f-caddfa25ba22",
-    "gadm36BoundariesLayer1": "b45350e3-5a76-44cd-b0a9-5038a0d8bfae",
-    "gadm36BoundariesLayer2": "cc35432d-38d7-4a03-872e-3a71a2f555fc"
+    "gadm36BoundariesDataset": "political-boundaries",
+    "gadm36BoundariesLayer1": "political-boundaries",
+    "gadm36BoundariesLayer2": "disputed-political-boundaries"
   }
 }

--- a/config/prod.json
+++ b/config/prod.json
@@ -6,15 +6,18 @@
     "dirLogFile": null
   },
   "layers": {
-    "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",
-    "gladAlertLayer": "8e4a527d-1bcd-4a12-82b0-5a108ffec452",
-    "umdLossGainLayerDataset": "b584954c-0d8d-40c6-859c-f3fdf3c2c5df",
-    "umdLossGainLayer": "49a80e70-ec52-4ef8-bcc6-fb2771d95b2c",
+    "gladAlertLayerDataset": "integrated-deforestation-alerts-8bit",
+    "gladAlertLayer": "integrated-deforestation-alerts-8bit",
+    "gladLAlertLayer": "integrated-deforestation-alerts-8bit-gladL",
+    "gladRaddAlertLayer": "integrated-deforestation-alerts-8bit-radd",
+    "gladSAlertLayer": "integrated-deforestation-alerts-8bit-s",
+    "umdLossGainLayerDataset": "tree-cover-loss",
+    "umdLossGainLayer": "tree-cover-loss",
     "viirsLayerDataset": "fire-alerts-viirs",
     "viirsLayer": "fire-alerts-viirs",
-    "gadm36BoundariesDataset": "0b0208b6-b424-4b57-984f-caddfa25ba22",
-    "gadm36BoundariesLayer1": "b45350e3-5a76-44cd-b0a9-5038a0d8bfae",
-    "gadm36BoundariesLayer2": "cc35432d-38d7-4a03-872e-3a71a2f555fc"
+    "gadm36BoundariesDataset": "political-boundaries",
+    "gadm36BoundariesLayer1": "political-boundaries",
+    "gadm36BoundariesLayer2": "disputed-political-boundaries"
   },
   "slack": {
     "enabled": true

--- a/config/staging.json
+++ b/config/staging.json
@@ -6,14 +6,17 @@
     "dirLogFile": null
   },
   "layers": {
-    "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",
-    "gladAlertLayer": "8e4a527d-1bcd-4a12-82b0-5a108ffec452",
-    "umdLossGainLayerDataset": "b584954c-0d8d-40c6-859c-f3fdf3c2c5df",
-    "umdLossGainLayer": "49a80e70-ec52-4ef8-bcc6-fb2771d95b2c",
+    "gladAlertLayerDataset": "integrated-deforestation-alerts-8bit",
+    "gladAlertLayer": "integrated-deforestation-alerts-8bit",
+    "gladLAlertLayer": "integrated-deforestation-alerts-8bit-gladL",
+    "gladRaddAlertLayer": "integrated-deforestation-alerts-8bit-radd",
+    "gladSAlertLayer": "integrated-deforestation-alerts-8bit-s",
+    "umdLossGainLayerDataset": "tree-cover-loss",
+    "umdLossGainLayer": "tree-cover-loss",
     "viirsLayerDataset": "fire-alerts-viirs",
     "viirsLayer": "fire-alerts-viirs",
-    "gadm36BoundariesDataset": "0b0208b6-b424-4b57-984f-caddfa25ba22",
-    "gadm36BoundariesLayer1": "b45350e3-5a76-44cd-b0a9-5038a0d8bfae",
-    "gadm36BoundariesLayer2": "cc35432d-38d7-4a03-872e-3a71a2f555fc"
+    "gadm36BoundariesDataset": "political-boundaries",
+    "gadm36BoundariesLayer1": "political-boundaries",
+    "gadm36BoundariesLayer2": "disputed-political-boundaries"
   }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -9,15 +9,18 @@
     "loadCron": false
   },
   "layers": {
-    "gladAlertLayerDataset": "bfd1d211-8106-4393-86c3-9e1ab2ee1b9b",
-    "gladAlertLayer": "8e4a527d-1bcd-4a12-82b0-5a108ffec452",
-    "umdLossGainLayerDataset": "b584954c-0d8d-40c6-859c-f3fdf3c2c5df",
-    "umdLossGainLayer": "49a80e70-ec52-4ef8-bcc6-fb2771d95b2c",
+    "gladAlertLayerDataset": "integrated-deforestation-alerts-8bit",
+    "gladAlertLayer": "integrated-deforestation-alerts-8bit",
+    "gladLAlertLayer": "integrated-deforestation-alerts-8bit-gladL",
+    "gladRaddAlertLayer": "integrated-deforestation-alerts-8bit-radd",
+    "gladSAlertLayer": "integrated-deforestation-alerts-8bit-s",
+    "umdLossGainLayerDataset": "tree-cover-loss",
+    "umdLossGainLayer": "tree-cover-loss",
     "viirsLayerDataset": "fire-alerts-viirs",
     "viirsLayer": "fire-alerts-viirs",
-    "gadm36BoundariesDataset": "0b0208b6-b424-4b57-984f-caddfa25ba22",
-    "gadm36BoundariesLayer1": "b45350e3-5a76-44cd-b0a9-5038a0d8bfae",
-    "gadm36BoundariesLayer2": "cc35432d-38d7-4a03-872e-3a71a2f555fc"
+    "gadm36BoundariesDataset": "political-boundaries",
+    "gadm36BoundariesLayer1": "political-boundaries",
+    "gadm36BoundariesLayer2": "disputed-political-boundaries"
   },
   "dataApi": {
     "apiKey": "example",

--- a/src/models/layer.ts
+++ b/src/models/layer.ts
@@ -32,19 +32,19 @@ const LAYERS: ILayer[] = [{
     slug: 'glad-l',
     subscription: true,
     datasetId: config.get('layers.gladAlertLayerDataset'),
-    layerId: config.get('layers.gladAlertLayer')
+    layerId: config.get('layers.gladLAlertLayer')
 }, {
     name: 'glad-s2',
     slug: 'glad-s2',
     subscription: true,
     datasetId: config.get('layers.gladAlertLayerDataset'),
-    layerId: config.get('layers.gladAlertLayer')
+    layerId: config.get('layers.gladSAlertLayer')
 }, {
     name: 'glad-radd',
     slug: 'glad-radd',
     subscription: true,
     datasetId: config.get('layers.gladAlertLayerDataset'),
-    layerId: config.get('layers.gladAlertLayer')
+    layerId: config.get('layers.gladRaddAlertLayer')
 }, {
     name: 'monthly-summary',
     slug: 'monthly-summary',


### PR DESCRIPTION
### Overview

When receiving a subscription email (see screenshot) for an area with deforestation alerts, if I click "see on the map," [no layers](https://www.globalforestwatch.org/map/aoi/62aa1fc3037745001a2d9c97/?lang=en&mainMap=eyJzaG93QW5hbHlzaXMiOnRydWV9&map=eyJjZW50ZXIiOnsibGF0IjotNC45NjQ1NzQ1NDcwMzQxNzYsImxuZyI6LTU2LjU4NTk0MTMxNDQ5NzU3fSwiem9vbSI6OS43ODkyODIyOTE5ODIxMTUsImJhc2VtYXAiOnsidmFsdWUiOiJwbGFuZXQiLCJjb2xvciI6IiIsIm5hbWUiOiJsYXRlc3QiLCJpbWFnZVR5cGUiOiJhbmFseXRpYyJ9LCJjYW5Cb3VuZCI6ZmFsc2UsImRhdGFzZXRzIjpbeyJkYXRhc2V0IjoiZ2xhZC1kZWZvcmVzdGF0aW9uLWFsZXJ0cyIsImxheWVycyI6WyJkZWZvcmVzdGF0aW9uLWFsZXJ0cy1nbGFkIl0sInRpbWVsaW5lUGFyYW1zIjp7InN0YXJ0RGF0ZUFic29sdXRlIjoiMjAyMi0wNi0wOSIsImVuZERhdGVBYnNvbHV0ZSI6IjIwMjItMDYtMTYiLCJzdGFydERhdGUiOiIyMDIyLTA2LTA5IiwiZW5kRGF0ZSI6IjIwMjItMDYtMTYiLCJ0cmltRW5kRGF0ZSI6IjIwMjItMDYtMTYifX0seyJkYXRhc2V0IjoicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJsYXllcnMiOlsicG9saXRpY2FsLWJvdW5kYXJpZXMiLCJkaXNwdXRlZC1wb2xpdGljYWwtYm91bmRhcmllcyJdfV19&mapMenu=eyJtZW51U2VjdGlvbiI6Im15LWdmdyJ9) are displayed except Planet. Users must turn on the alert layer and adjust the date range manually to see the alerts the email is referring to

### Acceptance criteria: 

- The “see on map” button will lead to whatever layer (RADD, GLAD-L, GLAD-S2, all integrated) the user originally subscribed to 
- Ideally, the date range in emails is shown on the map
- We will want to change the configuration on the URL
- We update this documentation page with anything we learn from this ticket: https://gfw.atlassian.net/wiki/spaces/FLAGDEV/pages/778960975/Subscriptions 
